### PR TITLE
chore: capture current build tooling baseline

### DIFF
--- a/.codex/progress.json
+++ b/.codex/progress.json
@@ -65,12 +65,15 @@
         "PLAN.md captures Gradle, Forge, mapping, and Java versions in use today.",
         "Identified upgrade gaps feeding into Stage S2 tasks."
       ],
-      "done": false,
+      "done": true,
       "commit": null,
       "blockers": [],
-      "touched": [],
+      "touched": [
+        "PLAN.md",
+        ".codex/progress.json"
+      ],
       "added_files": [],
-      "notes": ""
+      "notes": "Logged Gradle 7.5 wrapper, ForgeGradle 5.1, Forge 1.19.2-43.1.47, and Java 17 baseline."
     },
     {
       "id": "T002",
@@ -1974,7 +1977,7 @@
       "notes": ""
     }
   ],
-  "cursor": 0,
-  "last_run": "2025-10-05T14:13:55+00:00",
-  "notes": "Seeded plan awaiting execution."
+  "cursor": 1,
+  "last_run": "2025-10-05T14:19:17+00:00",
+  "notes": "Completed T001 build tooling baseline audit."
 }

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,12 +2,17 @@
 
 ## Stage S1 – Audit & Inventory
 
-- [ ] **T001** – Document build tooling baseline (_docs_) 
+- [x] **T001** – Document build tooling baseline (_docs_)
   - Targets: (docs only)
   - Description: Summarize current ForgeGradle/Forge/mapping versions and Java toolchain state in PLAN.md for migration context.
   - Acceptance criteria:
     - PLAN.md captures Gradle, Forge, mapping, and Java versions in use today.
     - Identified upgrade gaps feeding into Stage S2 tasks.
+  - Findings:
+    - Gradle wrapper pinned to **7.5** via `gradle/wrapper/gradle-wrapper.properties`.
+    - `build.gradle` uses **ForgeGradle 5.1.+** with **Forge 1.19.2-43.1.47** and **official 1.19.2 mappings**.
+    - Java toolchain already targets **Java 17**, matching the Minecraft 1.18+ baseline.
+    - Stage S2 tasks must lift wrapper to Gradle 8.x, adopt ForgeGradle 6, and switch to Mojang+Parchment mappings for 1.20.1.
 
 - [ ] **T002** – Document source layout and entrypoint gaps (_docs_) 
   - Targets: (docs only)


### PR DESCRIPTION
## Summary
- document the existing Gradle wrapper, ForgeGradle, Forge, and mapping versions to inform the 1.20.1 upgrade plan
- mark T001 complete in the migration tracker and advance the cursor for the next audit task

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e27e2a1c0883318360b173fc198cf6