### PR TITLE
Add API behavior inventory scanner and reports

### DIFF
--- a/inventory_v2/API_BEHAVIORS.md
+++ b/inventory_v2/API_BEHAVIORS.md
@@ -1,0 +1,191 @@
+# IndustrialCodex2 API Behavior Map
+
+## Energy / Cables
+### Network management
+- [DECLARED] **EnergyNet.INSTANCE** exposes a mutable singleton hook; implementations must inject an `IEnergyNet` before any tiles register.
+- [DECLARED] **IEnergyNet** supplies grid lookup (`getTile`, `getSubTile`, `getTiles`) and lifecycle callbacks (`addTile`, `removeTile`, `updateTile`). Implementations must translate world/position pairs to the matching `IEnergyTile`. 【F:src/main/java/ic2/api/energy/IEnergyNet.java†L1-L42】
+- [DECLARED] `IEnergyNet.getPowerFromTier(int)` and `getTierFromPower(int)` form the canonical tier↔packet size mapping in EU units. `getDisplayTier(int)` exposes localization-friendly tier names. 【F:src/main/java/ic2/api/energy/IEnergyNet.java†L18-L24】
+- [DECLARED] `IEnergyNet.getStats` and `getPacketStats` return aggregated `TransferStats` and per-packet `PacketStats` snapshots, indicating how much EU flowed in/out and whether a sink accepted packets. 【F:src/main/java/ic2/api/energy/IEnergyNet.java†L24-L40】【F:src/main/java/ic2/api/energy/TransferStats.java†L1-L35】【F:src/main/java/ic2/api/energy/PacketStats.java†L1-L35】
+
+### Tiles & conductors
+- [DECLARED] **IEnergyTile** inherits `ILocation`, so every tile must supply world/position context either via `BlockEntity` or explicit overrides. 【F:src/main/java/ic2/api/energy/tile/IEnergyTile.java†L1-L6】【F:src/main/java/ic2/api/util/ILocation.java†L1-L29】
+- [DECLARED] **IEnergyAcceptor** and **IEnergyEmitter** define directional gating via `canAcceptEnergy` / `canEmitEnergy`, called per-side before any transfer. 【F:src/main/java/ic2/api/energy/tile/IEnergyAcceptor.java†L1-L8】【F:src/main/java/ic2/api/energy/tile/IEnergyEmitter.java†L1-L8】
+- [DECLARED] **IEnergySink** sets per-sink behavior: `getSinkTier`, `getRequestedEnergy`, and `acceptEnergy(Direction side, int amount, int voltage)` to consume EU and report leftovers. 【F:src/main/java/ic2/api/energy/tile/IEnergySink.java†L1-L12】
+- [DECLARED] **IEnergySource** reports available EU (`getProvidedEnergy`, `getMaxEnergyOutput`), consumes the transferred amount via `consumeEnergy`, and may receive `onPacketFailed` callbacks when the net cannot route energy. Optional `SourceType` metadata distinguishes active/passive producers. 【F:src/main/java/ic2/api/energy/tile/IEnergySource.java†L1-L28】
+- [DECLARED] **IMultiEnergyTile/Source** bundle logical tiles or packet emitters; `IMultiEnergySource` exposes packet count info for multi-emission designs. 【F:src/main/java/ic2/api/energy/tile/IMultiEnergyTile.java†L1-L7】【F:src/main/java/ic2/api/energy/tile/IMultiEnergySource.java†L1-L7】
+- [DECLARED] **IEnergyConductor** bridges acceptor/emitter roles and reports physical properties: conduction loss (EU/tick), insulation absorption/breakdown thresholds, conductor breakdown, and removal hooks when overloaded or stripped. The default `isWaterlogged` helper inspects the hosting block state. 【F:src/main/java/ic2/api/energy/tile/IEnergyConductor.java†L1-L24】
+- [DECLARED] **IEnergyConductorModifiable** exposes runtime insulation toggles, while **IEnergyConductorColored** reports dye channels for routing overlays. Anchored conductors implement **IAnchorTile** to manage mechanical anchors per side. 【F:src/main/java/ic2/api/energy/tile/IEnergyConductorModifiable.java†L1-L8】【F:src/main/java/ic2/api/energy/tile/IEnergyConductorColored.java†L1-L8】【F:src/main/java/ic2/api/energy/tile/IEnergyConductorAnchored.java†L1-L6】【F:src/main/java/ic2/api/tiles/IAnchorTile.java†L1-L10】
+
+### Convenience wrappers
+- [DECLARED] **LinkedSink** / **LinkedSource** wrap bare block positions into temporary `IEnergyAcceptor`/`IEnergyEmitter` views, gating transfers by bitmask of allowed directions. Intended for multipart or multi-block controllers bridging into the net. 【F:src/main/java/ic2/api/energy/impl/LinkedSink.java†L1-L64】【F:src/main/java/ic2/api/energy/impl/LinkedSource.java†L1-L64】
+
+#### Implementation checklist
+- Ensure every energy tile returns stable world/position info via `ILocation`. [DECLARED]
+- Validate side-based access in `canAcceptEnergy` / `canEmitEnergy` before exposing neighbors. [DECLARED]
+- Clamp sink tiers/voltages to supported packet sizes using `IEnergyNet.getPowerFromTier`. [DECLARED]
+- Update energy requests before each tick so the net can plan packet routing. [INFERRED]
+- Surface insulation and breakdown values that match in-game cable specs to avoid desync. [INFERRED]
+- Call `consumeEnergy` only after the net confirms delivery to avoid duplicating EU. [DECLARED]
+- Invoke `updateTile` on state changes (tier, demand) so the grid recalculates flows. [INFERRED]
+- Provide SourceType metadata for proper transformer/producer heuristics. [INFERRED]
+
+## Reactor / Planner
+### Core reactor contracts
+- [DECLARED] **IReactor** exposes core heat bookkeeping (`getHeat`/`setHeat`/`addHeat`), capacity (`getMaxHeat`), heat effect modifier, per-tick energy accumulation, slot inventory (`getStackInReactor`/`setStackInReactor`), explosion trigger, tick interval, and production flag. EU output is modeled as double precision per tick. 【F:src/main/java/ic2/api/reactor/IReactor.java†L1-L32】
+- [DECLARED] **IChamberReactor** extends `IReactor` for expandable chambers, reporting grid dimensions and allowing `refreshChambers()` after structure changes. 【F:src/main/java/ic2/api/reactor/IChamberReactor.java†L1-L9】
+- [DECLARED] **IReactorChamber** surfaces a link back to the master reactor tile, while **ISteamReactorChamber** marks steam-specific chambers. 【F:src/main/java/ic2/api/reactor/IReactorChamber.java†L1-L6】【F:src/main/java/ic2/api/reactor/ISteamReactorChamber.java†L1-L5】
+- [DECLARED] **ISteamReactor** augments the core contract with `FluidTank` accessors for water/steam buffers, ensuring steam builds can pipe fluids. 【F:src/main/java/ic2/api/reactor/ISteamReactor.java†L1-L9】
+
+### Components & products
+- [DECLARED] **IReactorProduct** validates whether an `ItemStack` can occupy a reactor slot (`isValidForReactor`). Components default to `true`. 【F:src/main/java/ic2/api/reactor/IReactorProduct.java†L1-L7】【F:src/main/java/ic2/api/reactor/IReactorComponent.java†L1-L17】
+- [DECLARED] **IReactorComponent** drives per-slot simulation: `processChamber` (heat vs. damage phases), `acceptUraniumPulse` (cross-slot neutron interactions), heat storage queries (`canStoreHeat`, `getStoredHeat`, `getMaxStoredHeat`, `storeHeat`), and `getExplosionInfluence` for blast scaling. 【F:src/main/java/ic2/api/reactor/IReactorComponent.java†L11-L23】
+- [INFERRED] `processChamber`/`acceptUraniumPulse` are called every `IReactor.getTickRate()` cycle with `heatCalculation`/`damageTick` toggles to simulate asynchronous heat vs. wear. 【F:src/main/java/ic2/api/reactor/IReactorComponent.java†L11-L17】
+- [DECLARED] **IReactorPlannerComponent** extends component logic with planner utilities: enumerating craftable stacks (`provideComponents`), mapping to simulated IDs, reporting affected grid slots, supported reactor types (electric/steam/universal), component categories, and statistic exports via `ReactorStat` enumerations. 【F:src/main/java/ic2/api/reactor/IReactorPlannerComponent.java†L1-L124】
+- [DECLARED] Planner helper enums include `ComponentType` (indexed registry with localization keys) and `ReactorStat` (heat, energy, cooling, durability metrics). Some stats are floats, others ints, surfaced via `NumericTag`. 【F:src/main/java/ic2/api/reactor/IReactorPlannerComponent.java†L30-L124】
+
+### Simulation scaffolding
+- [DECLARED] **ISimulatedReactor** mirrors the runtime API, adding breed/fuel pulse counters, steam accounting, water consumption, production flags, and `getGameTime()` for time-based mechanics. 【F:src/main/java/ic2/api/reactor/planner/ISimulatedReactor.java†L1-L27】
+- [DECLARED] **SimulatedStack** instances mirror items during planner runs: serialization (`save`/`load`), state staging (`commitState`/`reset`), `simulate` tick hooks, heat/acceptance mirrors, explosion influence, metadata (id, stats, component type). Default helpers expose `NULL_VALUE` placeholders. 【F:src/main/java/ic2/api/reactor/planner/SimulatedStack.java†L1-L33】
+- [DECLARED] **BaseHeatSimulatedStack** tracks heat with a rolling `Tracker` (average/total sample, commit/reset) and clamps storage, marking stacks broken via `reactor.markBroken`. **BaseDurabilitySimulatedStack** provides similar scaffolding for damage-based parts. 【F:src/main/java/ic2/api/reactor/planner/BaseHeatSimulatedStack.java†L1-L53】【F:src/main/java/ic2/api/reactor/planner/Tracker.java†L1-L38】【F:src/main/java/ic2/api/reactor/planner/BaseDurabilitySimulatedStack.java†L1-L44】
+- [DECLARED] **FloatTracker** mirrors `Tracker` for non-integer metrics (e.g., EU output averages). 【F:src/main/java/ic2/api/reactor/planner/FloatTracker.java†L1-L20】
+
+#### Implementation checklist
+- Wire every reactor tile to provide accurate heat, max heat, and HEM readings; planner tooling reuses these values directly. [DECLARED]
+- Call `addOutput` each tick to accumulate EU for reporting interfaces. [DECLARED]
+- Ensure `getStackInReactor`/`setStackInReactor` remain synchronous with inventory handlers used by GUIs. [DECLARED]
+- Maintain slot coordinates consistent with planner grids (usually 6×9) to keep `IReactorPlannerComponent` overlays aligned. [INFERRED]
+- Components must respect `heatCalculation` vs `damageTick` to avoid double-dipping on wear. [INFERRED]
+- Provide meaningful `getExplosionInfluence` values so meltdown effects stack correctly. [DECLARED]
+- Surface `ReactorStat` metrics for planner UI (heat, cooling, durability, etc.) even if some return zero. [DECLARED]
+- For steam reactors, pipe `FluidTank` updates through Forge capabilities so heat-to-steam conversion can drain tanks. [INFERRED]
+
+## Tiles / Tubes / Teleport
+### Machine cores
+- [DECLARED] **IMachine** joins `ILocation` and `IInputMachine`, exposing upgrade support (`getSupportedUpgradeTypes`, `onUpgradesChanged`), EU buffer hooks (`getAvailableEnergy`, `useEnergy`), redstone toggles, and adjacency queries for inventories (`IItemHandler`) and adjacent tubes. Machines must also reveal working state for overlays. 【F:src/main/java/ic2/api/tiles/IMachine.java†L1-L19】
+- [DECLARED] **IInputMachine** reports remaining item capacity per `ItemStack`. 【F:src/main/java/ic2/api/tiles/IInputMachine.java†L1-L7】
+- [DECLARED] **IEnergyStorage** inherits `IEUStorage` telemetry and adds mutators `addEnergy` / `drawEnergy` in EU units. 【F:src/main/java/ic2/api/tiles/IEnergyStorage.java†L1-L8】
+- [DECLARED] **IElectrolyzerProvider**, **IFluidMachine**, **INotifiableMachine**, and related interfaces (see method catalog) specialize fluid access, progress tracking, and update hooks for GUIs. 【F:src/main/java/ic2/api/tiles/IElectrolyzerProvider.java†L1-L21】【F:src/main/java/ic2/api/tiles/IFluidMachine.java†L1-L18】
+- [INFERRED] **FakePlayerMachine** / anchor helpers coordinate server-side fake player interactions for tools or automation (based on naming). 【F:src/main/java/ic2/api/tiles/FakePlayerMachine.java†L1-L45】
+
+### Tubes & logistics
+- [DECLARED] **ITube** extends `ILocation`, providing item insertion (`addItem` overloads), capability checks (`canAddItem`), neighbor validation (`canConnect`), and metadata `TubeType` (simple vs extraction). Dye colors allow routing channels. 【F:src/main/java/ic2/api/tiles/tubes/ITube.java†L1-L20】
+- [DECLARED] **TransportedItem** models moving payloads: serialization (NBT/network), speed/position (0–100 progress, MIN/MAX speed), direction tracking (`setInsertionDirection`, `setExportDirection`), centering state, timeout invalidation, request IDs (UUID), and dye filters. Update loops must call `update()` to advance or time out. 【F:src/main/java/ic2/api/tiles/tubes/TransportedItem.java†L1-L214】【F:src/main/java/ic2/api/tiles/tubes/TransportedItem.java†L200-L252】
+- [DECLARED] **IProviderTube** and **IRequestTube** coordinate logistics requests, referencing UUID request IDs, dye filters, and callbacks to requesters (validate amount, issue requests). Providers also expose a long `getProviderSource` for priority/unique keys. 【F:src/main/java/ic2/api/tiles/tubes/IProviderTube.java†L1-L11】【F:src/main/java/ic2/api/tiles/tubes/IRequestTube.java†L1-L21】
+- [DECLARED] **ILimiterTube** constrains valid dye channels. 【F:src/main/java/ic2/api/tiles/tubes/ILimiterTube.java†L1-L8】
+- [DECLARED] **IItemCache** caches item snapshots for networking; servers `registerItem` returning IDs, clients `getItem(int)` returning lazy suppliers, and both sides may `updateCache` / `clearCache`. 【F:src/main/java/ic2/api/tiles/tubes/IItemCache.java†L1-L43】
+- [DECLARED] **ArrayTube** composes multiple `ITube` implementations, forwarding items round-robin (with optional looping) and forbidding transport-related queries by throwing `UnsupportedOperationException`. 【F:src/main/java/ic2/api/tiles/ArrayTube.java†L1-L38】
+
+### Teleportation
+- [DECLARED] **ITeleporterTarget** marks block entities that can send/receive teleport payloads, exposing facing, allowed transport types (`TeleportType`), and target bookkeeping (`setTarget`, `hasTarget`). `TeleportType.matches` handles entity/spawner equivalence. 【F:src/main/java/ic2/api/tiles/teleporter/ITeleporterTarget.java†L1-L28】
+- [DECLARED] **TeleporterTarget** stores serialized dimension/position pairs, supports network/NBT IO, equality, and helper constructors. `getWorld` resolves the server level, `getTile` fetches the destination block entity. 【F:src/main/java/ic2/api/tiles/teleporter/TeleporterTarget.java†L1-L88】
+- [DECLARED] **TargetRegistry** keeps a synchronized map of known targets to display names (non-persistent). 【F:src/main/java/ic2/api/tiles/teleporter/TargetRegistry.java†L1-L20】
+
+#### Implementation checklist
+- Keep machine energy usage synced with upgrades by recalculating after `onUpgradesChanged`. [DECLARED]
+- Always expose consistent `ITube` references per side so logistics filters stay deterministic. [DECLARED]
+- Update `TransportedItem` progress every tick and invalidate stalled packets to avoid ghost items. [DECLARED]
+- Respect dye/channel filters in `IProviderTube` and `IRequestTube` when routing requests. [DECLARED]
+- When implementing teleporters, validate `TeleportType.matches` before accepting payloads. [DECLARED]
+- Use `IItemCache.registerItem` when syncing TransportedItem payloads to minimize network payload size. [DECLARED]
+- For machines that spawn fake players, ensure thread-safety when performing block interactions. [INFERRED]
+- Clear target registry entries when tiles unload or break to prevent stale teleport destinations. [INFERRED]
+
+## Items / Readers / Electric
+### Core item traits
+- [DECLARED] **IElectricItem** defines capacity, tier, transfer limit, and `canProvideEnergy` toggles. Tiers align with energy net voltage steps. 【F:src/main/java/ic2/api/items/electric/IElectricItem.java†L1-L11】
+- [DECLARED] **IElectricItemManager** orchestrates charging/discharging (with simulate flags), current charge queries, transfer limit, tool usage gating (`canUse`/`use`), armor charging, tier lookup, and tooltip generation. 【F:src/main/java/ic2/api/items/electric/IElectricItemManager.java†L1-L24】
+- [DECLARED] **ElectricItem** maintains static managers: global `MANAGER`, `DIRECT_MANAGER`, backup lookups per item, optional Curios accessor, and helpers for charging armor/Curio slots and adjusting consumption by enchantments. Implementations must register managers before runtime use. 【F:src/main/java/ic2/api/items/electric/ElectricItem.java†L1-L74】
+- [DECLARED] **ICustomElectricItem** lets items supply bespoke managers, while **IDamagelessElectricItem** flags items without durability loss. 【F:src/main/java/ic2/api/items/electric/ICustomElectricItem.java†L1-L7】【F:src/main/java/ic2/api/items/electric/IDamagelessElectricItem.java†L1-L6】
+- [DECLARED] **IElectricEnchantable** customizes enchantment compatibility for electric gear. 【F:src/main/java/ic2/api/items/electric/IElectricEnchantable.java†L1-L11】
+
+### Tools & scanners
+- [DECLARED] **IScanner** / **IFluidScanner** supply scan radius and ore/fluid valuation callbacks; optional energy usage toggles allow preview vs actual scan. 【F:src/main/java/ic2/api/items/electric/IScanner.java†L1-L23】【F:src/main/java/ic2/api/items/electric/IFluidScanner.java†L1-L14】
+- [DECLARED] **IMiningDrill** determines mining permission, optional speed boosts/extra EU cost, and consumption hooks (`onDrillUsed`). 【F:src/main/java/ic2/api/items/electric/IMiningDrill.java†L1-L18】
+- [DECLARED] **IWrenchTool** modifies wrench drop loss and optionally toggles overlay rendering. 【F:src/main/java/ic2/api/items/readers/IWrenchTool.java†L1-L8】
+- [DECLARED] **IWrenchable** (block-side) describes rotation/removal flows, overlay bounding boxes, drop lists, and nested `WrenchRegistry` for registering handlers for vanilla blocks. Implementations must respect player direction, shift behavior, and drop chance semantics. 【F:src/main/java/ic2/api/blocks/IWrenchable.java†L1-L170】
+
+### Readers & upgrades
+- [DECLARED] **ICropReader**, **IEUReader**, **IThermometer** expose boolean checks with static helpers to detect tool capability from an `ItemStack`. 【F:src/main/java/ic2/api/items/readers/ICropReader.java†L1-L11】【F:src/main/java/ic2/api/items/readers/IEUReader.java†L1-L11】【F:src/main/java/ic2/api/items/readers/IThermometer.java†L1-L11】
+- [DECLARED] **IUpgradeItem** enumerates machine upgrade effects: type, functions, install hook, multipliers/offsets for time, speed, energy demand/storage, tier, sound, redstone inversion, tick callbacks, and recipe completion hooks (pre/post, access to drops and flags). UpgradeType describes which subsystems are touched. 【F:src/main/java/ic2/api/items/IUpgradeItem.java†L1-L73】
+- [DECLARED] **ItemRegistries** centralize registries for metal armor, boxable items, coins (value-ordered), shield blockable damage sources, etc. It also exposes coin generation utilities and registration APIs. 【F:src/main/java/ic2/api/items/ItemRegistries.java†L1-L117】
+
+#### Implementation checklist
+- Register your `IElectricItemManager` (or custom manager) before items attempt to charge/discharge. [DECLARED]
+- Respect `transferLimit` and `tier` checks inside `charge`/`discharge` operations; ignore-transfer-limit flags are only for internal wiring. [DECLARED]
+- Update wrenchable blocks to return accurate `AABB` overlays for client previews and guard `canRemoveBlock` vs drop rate semantics. [DECLARED]
+- When adding upgrades, populate all relevant multiplier/offset getters even if returning defaults. [DECLARED]
+- Ensure scanners honor `useEnergy` flags so client previews do not drain charge. [DECLARED]
+- Call `onDrillUsed` after successful block breaks to sync durability/charge usage. [DECLARED]
+- Leverage `ItemRegistries.registerCoin` / `generateCoins` to maintain consistent coin payout ratios. [DECLARED]
+- Keep reader interfaces idempotent so static helper checks remain cheap. [INFERRED]
+
+## Network / Buffer / Container
+### Manager & channels
+- [DECLARED] **INetworkManager** registers `INetworkDataBuffer` types by `ResourceLocation`, manages GUI tracking, syncs tile fields (initial + incremental), relays tile events (ints or custom buffers) with `PacketRange`, and mirrors similar flows for held items. Client senders have dedicated helpers (`sendClientTileEvent`, etc.). 【F:src/main/java/ic2/api/network/INetworkManager.java†L1-L44】
+- [DECLARED] **PacketRange** enumerates broadcast radii (short/long/chunk/all-dim/server) for tile events. 【F:src/main/java/ic2/api/network/tile/PacketRange.java†L1-L7】
+
+### Data buffers
+- [DECLARED] **INetworkDataBuffer** defines `write(IOutputBuffer)` / `read(IInputBuffer)` pairs; each buffer type must be registered. 【F:src/main/java/ic2/api/network/buffer/INetworkDataBuffer.java†L1-L7】
+- [DECLARED] **IOutputBuffer** / **IInputBuffer** cover primitive serialization, Forge registry entries, ItemStack/FluidStack, UUID, NBT, registry keys, and `NetworkInfo.BitLevel` granular bit packing. Convenience statics help writing stacks/enums. 【F:src/main/java/ic2/api/network/buffer/IOutputBuffer.java†L1-L35】【F:src/main/java/ic2/api/network/buffer/IInputBuffer.java†L1-L33】
+- [DECLARED] **NetworkInfo** annotation tags fields with bit-level compression guidance (ignore, 8–64 bits) and runtime helpers (`isValid`, `limitNumber`). 【F:src/main/java/ic2/api/network/buffer/NetworkInfo.java†L1-L49】
+- [DECLARED] **EmptyDataBuffer** (see catalog) acts as a no-op placeholder for events with no payload. 【F:src/main/java/ic2/api/network/buffer/EmptyDataBuffer.java†L1-L18】
+
+### Tile & item listeners
+- [DECLARED] **INetworkFieldProvider** lists auto-synced fields for tiles (`getNetworkFields`, `getGuiFields`, optional `isDefaultData`). Implementers must ensure stable field names. 【F:src/main/java/ic2/api/network/tile/INetworkFieldProvider.java†L1-L8】
+- [DECLARED] **INetworkFieldNotifier** receives sets of changed field names for both server-origin updates (`onNetworkFieldChanged`) and GUI-specific updates. 【F:src/main/java/ic2/api/network/tile/INetworkFieldNotifier.java†L1-L9】
+- [DECLARED] **INetworkEventListener** and **INetworkClientEventListener** handle int-based events; the latter includes the sending player. **INetworkDataEventListener** mirrors this for custom buffers with client/server `Dist` context. 【F:src/main/java/ic2/api/network/tile/INetworkEventListener.java†L1-L5】【F:src/main/java/ic2/api/network/tile/INetworkClientEventListener.java†L1-L7】【F:src/main/java/ic2/api/network/tile/INetworkDataEventListener.java†L1-L9】
+- [DECLARED] **INetworkItemEvent** / **INetworkItemBufferEvent** deliver item-bound events or buffers to specific players/hand slots, including target side metadata. 【F:src/main/java/ic2/api/network/item/INetworkItemEvent.java†L1-L9】【F:src/main/java/ic2/api/network/item/INetworkItemBufferEvent.java†L1-L9】
+- [DECLARED] **IPlayerPacket** supplies helper utilities to resolve containers or find held item stacks when processing network callbacks. 【F:src/main/java/ic2/api/network/IPlayerPacket.java†L1-L26】
+- [DECLARED] **IContainerDataEvent** is a lightweight hook for container-level (menu) integer syncs. 【F:src/main/java/ic2/api/network/container/IContainerDataEvent.java†L1-L5】
+
+#### Implementation checklist
+- Register every custom `INetworkDataBuffer` on mod init via `INetworkManager.registerDataBuffer`. [DECLARED]
+- Populate `INetworkFieldProvider` lists with deterministic ordering so delta comparisons work. [DECLARED]
+- When sending item events, use `IPlayerPacket.findPlayerStack` to locate the authoritative stack instance. [DECLARED]
+- Choose `PacketRange` carefully to avoid leaking tile updates across dimensions. [DECLARED]
+- Guard `onNetworkFieldChanged` handlers against client-only invocation when the player argument may be null. [INFERRED]
+- Reset GUI tracking via `updateGuiField(s)` when server-side values change outside normal ticks. [DECLARED]
+- Use `IOutputBuffer.writeData` with appropriate `BitLevel` to minimize network size. [DECLARED]
+- Throttle item buffer events; repeated large buffers can overwhelm channel bandwidth. [INFERRED]
+
+## Recipes / Registries
+### Central registry access
+- [DECLARED] **RecipeRegistry** exposes static holders for ingredient parsing, shaped craft managers, machine recipe lists (macerator, extractor, compressor, sawmill, etc.), scrap box rewards, fluid fuels, fusion recipes, can effects, potion brewing, and UU matter shapes. Many are `SidedObject` wrappers to segregate client/server registration. 【F:src/main/java/ic2/api/recipes/RecipeRegistry.java†L1-L37】
+
+### Machine recipe lists
+- [DECLARED] **IMachineRecipeList** manages `RecipeEntry` objects (id, inputs array, output, null-input flag). Helpers add simple/chance/range recipes (by `ResourceLocation`, optional NBT, XP). Input objects are converted via `RecipeRegistry.INGREDIENTS.createInputFrom`. Retrieval supports lookups by ID, matching stack, or predicate, plus removal and enumeration. 【F:src/main/java/ic2/api/recipes/registries/IMachineRecipeList.java†L1-L123】
+- [DECLARED] `RecipeEntry` stores whether any `INullableInput` is present (affecting processing). 【F:src/main/java/ic2/api/recipes/registries/IMachineRecipeList.java†L87-L121】
+- [DECLARED] **IAdvancedCraftingManager** (see catalog) handles shaped/shapeless registration, ore dictionary conversions, and recipe removal by key. 【F:src/main/java/ic2/api/recipes/registries/IAdvancedCraftingManager.java†L1-L44】
+- [DECLARED] Specialized registries expose domain-specific hooks: e.g., **ICannerRecipeRegistry** registers fluid/item combos, **IElectrolyzerRecipeList** maps fluids to outputs/energy cost, **IFusionRecipeList** handles multi-input EU-intensive recipes, **IFluidFuelRegistry** enumerates burnable fluids with EU output. (See method catalog for method lists.)
+- [DECLARED] **IIngredientRegistry** converts arbitrary objects (item stacks, tags, custom wrappers) into `IInput` abstractions and supports caching. (Detailed methods in catalog.)
+- [DECLARED] **IUUMatterRegistry** returns shape IDs and `NonNullList` outputs for UU crafting; keyed by dimension (via `SidedObject`).
+
+### Recipe flags & misc
+- [DECLARED] `recipes.misc.RecipeFlags` enum defines boolean/float flags applied to recipe outputs (heat usage, fluid rate, etc.), enabling planner overlays. 【F:src/main/java/ic2/api/recipes/misc/RecipeFlags.java†L1-L80】
+- [DECLARED] Queue APIs (under `ingridients.queue`) expose asynchronous recipe processing semantics (IStackOutput, etc.), ensuring machine outputs can be scheduled. (See catalog.)
+
+#### Implementation checklist
+- Initialize `RecipeRegistry.INGREDIENTS` before any machine tries to convert inputs. [DECLARED]
+- Register recipes via provided helpers to ensure consistent `RecipeEntry` creation and null-input detection. [DECLARED]
+- Use `SidedObject#get` correctly: server registrations should run on the logical server thread only. [DECLARED]
+- When adding removal logic, target recipes by `ResourceLocation` to avoid collateral deletions. [DECLARED]
+- Supply XP, chance, and range metadata where appropriate so downstream GUIs can display production stats. [DECLARED]
+- Keep custom ingredient converters thread-safe if they cache inputs. [INFERRED]
+- For queue-based outputs, emit `IStackOutput` in deterministic order to match auto-ejection expectations. [INFERRED]
+- Document custom recipe flags and honor them in machines that inspect `CompoundTag` recipe data. [INFERRED]
+
+## Events
+- [DECLARED] **FoamEvent.Check** fires before scaffolding/foam placement; listeners can override target type or cancel. **FoamEvent.Place** allows requesting forced foam placement or cancellation. TargetType enumerates structural categories (scaffold, cable, tube, pipe, custom). 【F:src/main/java/ic2/api/events/FoamEvent.java†L1-L67】
+- [DECLARED] **LaserEvent** (and subclasses) fire for laser tool actions: `LaserShootEvent` (item firing), `LaserExplodeEvent` (explosion parameters), `LaserEntityHitEvent` (entity collisions, pass-through toggle), `LaserBlockHitEvent` (block impact, drop chance). All are cancelable to let mods modify range/power/drops. 【F:src/main/java/ic2/api/events/LaserEvent.java†L1-L70】
+- [DECLARED] **RetextureEvent** notifies when painters attempt to apply block textures; exposes position, side, player, texture container (block state, rotations, colors). Listeners can mark the event as applied or mutate texture data. 【F:src/main/java/ic2/api/events/RetextureEvent.java†L1-L83】
+- [DECLARED] **ScrapBoxEvent** triggers when scrap boxes roll drops, with variants for player use (`ScrapBoxPlayerUseEvent`) and dispenser usage (`ScrapBoxDispenseEvent`). Listeners can inspect/replace drop lists. 【F:src/main/java/ic2/api/events/ScrapBoxEvent.java†L1-L44】
+- [DECLARED] **ArmorSlotEvent** announces available module slots for armor pieces, allowing listeners to grant additional module capacity per `ModuleType`. 【F:src/main/java/ic2/api/events/ArmorSlotEvent.java†L1-L33】
+
+#### Implementation checklist
+- Subscribe to foam events to whitelist additional blocks/cables before foam auto-placement occurs. [DECLARED]
+- Adjust laser event parameters (power, block breaks, pass-through) to integrate protective shields or alternate drop logic. [DECLARED]
+- Use `RetextureEvent` to veto or customize painter applications on custom blocks. [DECLARED]
+- When modifying scrap box drops, replace the `List<ItemStack>` in-place to keep dispenser logic consistent. [DECLARED]
+- Update armor module slot counts during `ArmorSlotEvent` with `addSlots`, but clamp totals (API enforces max of 9). [DECLARED]
+- Remember to respect cancelable flags; returning without calling `setApplied(true)` or `requestFoamPlacement()` leaves behavior unchanged. [INFERRED]
+

--- a/inventory_v2/api_contracts.json
+++ b/inventory_v2/api_contracts.json
@@ -1,0 +1,5536 @@
+{
+  "packages": [
+    "ic2.api.addons",
+    "ic2.api.blocks",
+    "ic2.api.blocks.wrench",
+    "ic2.api.core",
+    "ic2.api.crops",
+    "ic2.api.energy",
+    "ic2.api.energy.impl",
+    "ic2.api.energy.tile",
+    "ic2.api.events",
+    "ic2.api.items",
+    "ic2.api.items.armor",
+    "ic2.api.items.electric",
+    "ic2.api.items.readers",
+    "ic2.api.network",
+    "ic2.api.network.buffer",
+    "ic2.api.network.container",
+    "ic2.api.network.item",
+    "ic2.api.network.tile",
+    "ic2.api.reactor",
+    "ic2.api.reactor.planner",
+    "ic2.api.recipes",
+    "ic2.api.recipes.ingridients.generators",
+    "ic2.api.recipes.ingridients.inputs",
+    "ic2.api.recipes.ingridients.queue",
+    "ic2.api.recipes.ingridients.recipes",
+    "ic2.api.recipes.misc",
+    "ic2.api.recipes.registries",
+    "ic2.api.ticks",
+    "ic2.api.tiles",
+    "ic2.api.tiles.display",
+    "ic2.api.tiles.display.impl",
+    "ic2.api.tiles.readers",
+    "ic2.api.tiles.teleporter",
+    "ic2.api.tiles.tubes",
+    "ic2.api.util"
+  ],
+  "interfaces": [
+    {
+      "fqcn": "ic2.api.addons.IModule",
+      "methods": [
+        {
+          "name": "canLoad",
+          "sig": "boolean canLoad(Dist side)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "loadConfigs",
+          "sig": "void loadConfigs()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "preInit",
+          "sig": "void preInit(IEventBus modBus)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "postInit",
+          "sig": "void postInit()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.blocks.IAdvancedComparable",
+      "methods": [
+        {
+          "name": "getComparatorInputOverride",
+          "sig": "int getComparatorInputOverride(BlockState state, Level world, BlockPos pos, Direction side)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.blocks.IWrenchable",
+      "methods": [
+        {
+          "name": "getFacing",
+          "sig": "Direction getFacing(BlockState state, Level world, BlockPos pos);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "canSetFacing",
+          "sig": "boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "setFacing",
+          "sig": "boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "doSpecialAction",
+          "sig": "boolean doSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "hasSpecialAction",
+          "sig": "AABB hasSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "canRemoveBlock",
+          "sig": "boolean canRemoveBlock(BlockState state, Level world, BlockPos pos, Player player);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "getDropRate",
+          "sig": "double getDropRate(BlockState state, Level world, BlockPos pos, Player player);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "getDrops",
+          "sig": "List<ItemStack> getDrops(BlockState state, Level world, BlockPos pos, Player player);",
+          "notes": "DECLARED (fallback)"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other",
+      "source": "ic2/api/blocks/IWrenchable.java"
+    },
+    {
+      "fqcn": "ic2.api.blocks.IPaintable",
+      "methods": [
+        {
+          "name": "recolor",
+          "sig": "boolean recolor(BlockState state, Level world, BlockPos pos, Vec3 exactClick, Direction dir, DyeColor color);",
+          "notes": "DECLARED (fallback)"
+        },
+        {
+          "name": "getColor",
+          "sig": "DyeColor getColor(BlockState state);",
+          "notes": "DECLARED (fallback)"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other",
+      "source": "ic2/api/blocks/PainterHelper.java"
+    },
+    {
+      "fqcn": "ic2.api.core.APIHelper",
+      "methods": [
+        {
+          "name": "getFluidContainers",
+          "sig": "List<ItemStack> getFluidContainers(Fluid fluid)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "createSteam",
+          "sig": "FluidStack createSteam(int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTickHelper",
+          "sig": "ITickScheduler getTickHelper()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNetworkManager",
+          "sig": "INetworkManager getNetworkManager()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNetworkManager",
+          "sig": "INetworkManager getNetworkManager(Dist side)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ICropModifier",
+      "methods": [
+        {
+          "name": "canChangeSeedMode",
+          "sig": "boolean canChangeSeedMode(ItemStack input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canToggleSeedMode",
+          "sig": "boolean canToggleSeedMode(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ICropRenderer",
+      "methods": [
+        {
+          "name": "createQuadsForStage",
+          "sig": "List<BakedQuad> createQuadsForStage(int stage, boolean fancy, FaceBakery baker)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ICropSeed",
+      "methods": [
+        {
+          "name": "getCrop",
+          "sig": "ICrop getCrop(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getScanLevel",
+          "sig": "int getScanLevel(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setScanLevel",
+          "sig": "void setScanLevel(ItemStack stack, int level)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "increaseScanLevel",
+          "sig": "void increaseScanLevel(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowth",
+          "sig": "int getGrowth(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setGrowth",
+          "sig": "void setGrowth(ItemStack stack, int growth)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGain",
+          "sig": "int getGain(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setGain",
+          "sig": "void setGain(ItemStack stack, int gain)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getResistance",
+          "sig": "int getResistance(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setResistance",
+          "sig": "void setResistance(ItemStack stack, int resistance)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "SCAN_COST",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "TIERS",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ICropTile",
+      "methods": [
+        {
+          "name": "getFarmland",
+          "sig": "IFarmland getFarmland()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isWaterLogged",
+          "sig": "boolean isWaterLogged()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setWaterlogged",
+          "sig": "void setWaterlogged(boolean water)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCrop",
+          "sig": "ICrop getCrop()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setCrop",
+          "sig": "void setCrop(ICrop crop)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowthStage",
+          "sig": "int getGrowthStage()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setGrowthStage",
+          "sig": "void setGrowthStage(int stage)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowthPoints",
+          "sig": "int getGrowthPoints()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setGrowthPoints",
+          "sig": "void setGrowthPoints(int points)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getScanLevel",
+          "sig": "int getScanLevel()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setScanLevel",
+          "sig": "void setScanLevel(int level)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isCrossBreeding",
+          "sig": "boolean isCrossBreeding()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setCrossBreeding",
+          "sig": "void setCrossBreeding(boolean breed)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGainStat",
+          "sig": "int getGainStat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setGainStat",
+          "sig": "void setGainStat(int level)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowthStat",
+          "sig": "int getGrowthStat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setGrowthStat",
+          "sig": "void setGrowthStat(int level)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getResistanceStat",
+          "sig": "int getResistanceStat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setResistanceStat",
+          "sig": "void setResistanceStat(int level)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canBreed",
+          "sig": "boolean canBreed()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "requestStateUpdate",
+          "sig": "void requestStateUpdate()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onCustomDataChanged",
+          "sig": "void onCustomDataChanged()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "calculateGrowthSpeed",
+          "sig": "int calculateGrowthSpeed()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "performManualHarvest",
+          "sig": "boolean performManualHarvest()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "performHarvest",
+          "sig": "List<ItemStack> performHarvest(boolean manual)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "pickCrop",
+          "sig": "boolean pickCrop()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeCrop",
+          "sig": "void removeCrop()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isBlockBelow",
+          "sig": "boolean isBlockBelow(BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isBlockBelow",
+          "sig": "boolean isBlockBelow(Block block)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isBlockBelow",
+          "sig": "boolean isBlockBelow(TagKey<Block> tag)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getBlocksBelow",
+          "sig": "Set<Block> getBlocksBelow()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCustomData",
+          "sig": "CompoundTag getCustomData()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getLightLevel",
+          "sig": "int getLightLevel()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnvironmentQuality",
+          "sig": "int getEnvironmentQuality()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNutrients",
+          "sig": "int getNutrients()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHumidity",
+          "sig": "int getHumidity()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getWaterStorage",
+          "sig": "int getWaterStorage()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setWaterStorage",
+          "sig": "void setWaterStorage(int water)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFertilizerStorage",
+          "sig": "int getFertilizerStorage()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setFertilizerStorage",
+          "sig": "void setFertilizerStorage(int fertilizer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getWeedExStorage",
+          "sig": "int getWeedExStorage()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setWeedExStorage",
+          "sig": "void setWeedExStorage(int weedEx)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "createSeeds",
+          "sig": "ItemStack createSeeds(ICrop crop, int growthStat, int gainStat, int resistanceStat, int scanLevel)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ILocation"
+      ],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.IFarmland",
+      "methods": [
+        {
+          "name": "getHumidity",
+          "sig": "int getHumidity(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHumidity",
+          "sig": "int getHumidity(BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNutrients",
+          "sig": "int getNutrients(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNutrients",
+          "sig": "int getNutrients(BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isSpecial",
+          "sig": "boolean isSpecial()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSpecialState",
+          "sig": "BlockState getSpecialState(Block block)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ISeedCrop",
+      "methods": [
+        {
+          "name": "isDroppingSeeds",
+          "sig": "boolean isDroppingSeeds(ICropTile tile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSeedDrops",
+          "sig": "ItemStack[] getSeedDrops(ICropTile tile)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ISubSoil",
+      "methods": [
+        {
+          "name": "getHumidity",
+          "sig": "int getHumidity(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHumidity",
+          "sig": "int getHumidity(BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNutrients",
+          "sig": "int getNutrients(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNutrients",
+          "sig": "int getNutrients(BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isSpecial",
+          "sig": "boolean isSpecial()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSpecialState",
+          "sig": "BlockState getSpecialState(Block block)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.energy.IEnergyNet",
+      "methods": [
+        {
+          "name": "getTile",
+          "sig": "IEnergyTile getTile(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSubTile",
+          "sig": "IEnergyTile getSubTile(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTiles",
+          "sig": "GridTile getTiles(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addTile",
+          "sig": "void addTile(IEnergyTile tile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeTile",
+          "sig": "void removeTile(IEnergyTile tile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateTile",
+          "sig": "void updateTile(IEnergyTile tile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getPowerFromTier",
+          "sig": "int getPowerFromTier(int tier)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTierFromPower",
+          "sig": "int getTierFromPower(int power)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDisplayTier",
+          "sig": "String getDisplayTier(int tier)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStats",
+          "sig": "TransferStats getStats(IEnergyTile tile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getPacketStats",
+          "sig": "List<PacketStats> getPacketStats(IEnergyTile tile)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyAcceptor",
+      "methods": [
+        {
+          "name": "canAcceptEnergy",
+          "sig": "boolean canAcceptEnergy(IEnergyEmitter emitter, Direction side)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyTile"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyConductor",
+      "methods": [
+        {
+          "name": "isWaterlogged",
+          "sig": "boolean isWaterlogged()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isLavaLogged",
+          "sig": "boolean isLavaLogged()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getConductionLoss",
+          "sig": "double getConductionLoss()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getInsulationEnergyAbsorption",
+          "sig": "int getInsulationEnergyAbsorption()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getInsulationBreakdownEnergy",
+          "sig": "int getInsulationBreakdownEnergy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getConductorBreakdownEnergy",
+          "sig": "int getConductorBreakdownEnergy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeInsulation",
+          "sig": "void removeInsulation()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeConductor",
+          "sig": "void removeConductor()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyAcceptor",
+        "IEnergyEmitter"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyConductorAnchored",
+      "methods": [],
+      "constants": [],
+      "related": [
+        "IEnergyConductor",
+        "IAnchorTile"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyConductorColored",
+      "methods": [
+        {
+          "name": "getColor",
+          "sig": "DyeColor getColor()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyConductor"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyConductorModifiable",
+      "methods": [
+        {
+          "name": "tryAddInsulation",
+          "sig": "boolean tryAddInsulation()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "tryRemoveInsulation",
+          "sig": "boolean tryRemoveInsulation()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyConductor"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyEmitter",
+      "methods": [
+        {
+          "name": "canEmitEnergy",
+          "sig": "boolean canEmitEnergy(IEnergyAcceptor acceptor, Direction side)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyTile"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergySink",
+      "methods": [
+        {
+          "name": "getSinkTier",
+          "sig": "int getSinkTier()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRequestedEnergy",
+          "sig": "int getRequestedEnergy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "acceptEnergy",
+          "sig": "int acceptEnergy(Direction side, int amount, int voltage)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyAcceptor"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergySource",
+      "methods": [
+        {
+          "name": "getSourceTier",
+          "sig": "int getSourceTier()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxEnergyOutput",
+          "sig": "int getMaxEnergyOutput()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getProvidedEnergy",
+          "sig": "int getProvidedEnergy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "consumeEnergy",
+          "sig": "void consumeEnergy(int consumed)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onPacketFailed",
+          "sig": "void onPacketFailed()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSourceType",
+          "sig": "SourceType getSourceType()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyEmitter"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IEnergyTile",
+      "methods": [],
+      "constants": [],
+      "related": [
+        "ILocation"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IMultiEnergySource",
+      "methods": [
+        {
+          "name": "hasMultiplePackets",
+          "sig": "boolean hasMultiplePackets()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getPacketCount",
+          "sig": "int getPacketCount()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergySource"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.energy.tile.IMultiEnergyTile",
+      "methods": [
+        {
+          "name": "getTiles",
+          "sig": "List<IEnergyTile> getTiles()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyTile"
+      ],
+      "domain": "energy"
+    },
+    {
+      "fqcn": "ic2.api.items.IAutoEatable",
+      "methods": [
+        {
+          "name": "canAutoEat",
+          "sig": "boolean canAutoEat(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFoodValue",
+          "sig": "int getFoodValue(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onEaten",
+          "sig": "ItemStack onEaten(ItemStack stack, Level level, Player player)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IBoxableItem",
+      "methods": [
+        {
+          "name": "canStoreIntoBox",
+          "sig": "boolean canStoreIntoBox(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.ICoinItem",
+      "methods": [
+        {
+          "name": "getMoneyValue",
+          "sig": "int getMoneyValue(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.ICutterItem",
+      "methods": [
+        {
+          "name": "cutInsulation",
+          "sig": "void cutInsulation(Player player, ItemStack stack, Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IDisplayProvider",
+      "methods": [
+        {
+          "name": "provideInfo",
+          "sig": "void provideInfo(ItemStack stack, Consumer<IDisplayInfo> infos)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IDrinkContainer",
+      "methods": [
+        {
+          "name": "getCapacity",
+          "sig": "int getCapacity()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getContent",
+          "sig": "IDrinkableFluid getContent(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasContent",
+          "sig": "boolean hasContent(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "fillWith",
+          "sig": "ItemStack fillWith(IDrinkableFluid fluid, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEmptyContainer",
+          "sig": "ItemStack getEmptyContainer()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IFoamOverrider",
+      "methods": [],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IFuelableItem",
+      "methods": [
+        {
+          "name": "fill",
+          "sig": "ItemStack fill(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canFuel",
+          "sig": "boolean canFuel(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasFuel",
+          "sig": "boolean hasFuel(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFuel",
+          "sig": "int getFuel(ItemStack stack, int requested, boolean doDrain)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IRepairable",
+      "methods": [
+        {
+          "name": "repairDamage",
+          "sig": "boolean repairDamage(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ItemLike"
+      ],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.ITagBlock",
+      "methods": [
+        {
+          "name": "matches",
+          "sig": "boolean matches(ItemStack self, Block block)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getBlocks",
+          "sig": "List<Block> getBlocks(ItemStack self)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.ITagItem",
+      "methods": [
+        {
+          "name": "matches",
+          "sig": "boolean matches(ItemStack self, ItemStack toCompare)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.ITerraformerBP",
+      "methods": [
+        {
+          "name": "canInsert",
+          "sig": "boolean canInsert(ItemStack stack, Player player, Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onInsert",
+          "sig": "void onInsert(ItemStack stack, Player player, Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isRandomized",
+          "sig": "boolean isRandomized(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnergyUsage",
+          "sig": "int getEnergyUsage(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRadius",
+          "sig": "int getRadius(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "terraform",
+          "sig": "boolean terraform(ItemStack stack, Level world, BlockPos position, ITerraformer terraformer)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IUpgradeItem",
+      "methods": [
+        {
+          "name": "getType",
+          "sig": "UpgradeType getType(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFunctions",
+          "sig": "EnumSet<Functions> getFunctions(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onInstall",
+          "sig": "void onInstall(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getProcessingSpeedMultiplier",
+          "sig": "double getProcessingSpeedMultiplier(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExtraProcessingSpeed",
+          "sig": "int getExtraProcessingSpeed(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getProcessingTimeMultiplier",
+          "sig": "double getProcessingTimeMultiplier(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExtraProcessingTime",
+          "sig": "int getExtraProcessingTime(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnergyDemandMultiplier",
+          "sig": "double getEnergyDemandMultiplier(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExtraEnergyDemand",
+          "sig": "int getExtraEnergyDemand(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnergyStorageMultiplier",
+          "sig": "double getEnergyStorageMultiplier(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExtraEnergyStorage",
+          "sig": "int getExtraEnergyStorage(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExtraTier",
+          "sig": "int getExtraTier(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSoundMultiplier",
+          "sig": "float getSoundMultiplier(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "useRedstoneInvertion",
+          "sig": "boolean useRedstoneInvertion(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onTick",
+          "sig": "void onTick(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onMachineFinishedRecipePre",
+          "sig": "void onMachineFinishedRecipePre(ItemStack stack, IMachine machine, IRecipeOutput output, CompoundTag recipeFlags)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onMachineFinishedRecipePost",
+          "sig": "void onMachineFinishedRecipePost(ItemStack stack, IMachine machine, RecipeEntry entry, List<IStackOutput> drops)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onMachineProcessed",
+          "sig": "void onMachineProcessed(ItemStack stack, IMachine machine)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.IWindmillBlade",
+      "methods": [
+        {
+          "name": "getRadius",
+          "sig": "int getRadius(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEffectiveness",
+          "sig": "float getEffectiveness(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTexture",
+          "sig": "ResourceLocation getTexture(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.armor.IArmorHud",
+      "methods": [
+        {
+          "name": "isHudEnabled",
+          "sig": "boolean isHudEnabled(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.armor.IArmorModule",
+      "methods": [
+        {
+          "name": "getType",
+          "sig": "ModuleType getType(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canInstallInArmor",
+          "sig": "boolean canInstallInArmor(ItemStack stack, ItemStack armor, EquipmentSlot type)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onInstall",
+          "sig": "void onInstall(ItemStack stack, ItemStack armor, IArmorModuleHolder holder)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onUninstall",
+          "sig": "void onUninstall(ItemStack stack, ItemStack armor, IArmorModuleHolder holder)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "transferToArmor",
+          "sig": "void transferToArmor(ItemStack stack, ItemStack oldArmor, ItemStack newArmor)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onTick",
+          "sig": "void onTick(ItemStack stack, ItemStack armor, Level world, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onEquipped",
+          "sig": "void onEquipped(ItemStack stack, ItemStack armor, Player entity)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onUnequipped",
+          "sig": "void onUnequipped(ItemStack stack, ItemStack armor, Player entity)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "provideCapabilities",
+          "sig": "void provideCapabilities(ItemStack stack, ItemStack armor)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "handlePacket",
+          "sig": "boolean handlePacket(Player player, ItemStack module, ItemStack armor, String id, INetworkDataBuffer buffer, Dist targetSide)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "handleToolTip",
+          "sig": "void handleToolTip(ItemStack stack, Consumer<MutableComponent> results)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.armor.ICustomArmor",
+      "methods": [
+        {
+          "name": "getProperties",
+          "sig": "AbsorptionProperties getProperties(LivingEntity entity, ItemStack armor, DamageSource source, double damage, EquipmentSlot slot)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "damageArmor",
+          "sig": "void damageArmor(LivingEntity player, ItemStack stack, DamageSource source, int damage, EquipmentSlot slot, DamageType type)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canBlockDamageSource",
+          "sig": "boolean canBlockDamageSource(LivingEntity player, ItemStack stack, DamageSource source, EquipmentSlot slot)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.armor.IEnergyShieldArmor",
+      "methods": [
+        {
+          "name": "addsShieldEffect",
+          "sig": "boolean addsShieldEffect(EquipmentSlot type, LivingEntity entity, ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isEffectAlwaysOn",
+          "sig": "boolean isEffectAlwaysOn(EquipmentSlot type, LivingEntity entity, ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addsEnergyShieldEffect",
+          "sig": "boolean addsEnergyShieldEffect(LivingEntity living)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "shouldAlwaysShowEffect",
+          "sig": "boolean shouldAlwaysShowEffect(LivingEntity living)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.armor.IFoamSupplier",
+      "methods": [
+        {
+          "name": "canProvideFoam",
+          "sig": "boolean canProvideFoam(Player player, ItemStack stack, InventoryType inv, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "useFoam",
+          "sig": "void useFoam(Player player, ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFreeFoamSpace",
+          "sig": "int getFreeFoamSpace(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "fillFoam",
+          "sig": "void fillFoam(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.armor.IMetalArmor",
+      "methods": [
+        {
+          "name": "isMetalArmor",
+          "sig": "boolean isMetalArmor(ItemStack stack, Player player, EquipmentSlot targetSlot)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.ICustomElectricItem",
+      "methods": [
+        {
+          "name": "getManager",
+          "sig": "IElectricItemManager getManager(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IDamagelessElectricItem",
+      "methods": [],
+      "constants": [],
+      "related": [
+        "IElectricItem"
+      ],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IElectricEnchantable",
+      "methods": [
+        {
+          "name": "getEnchantmentCompatibility",
+          "sig": "InteractionResult getEnchantmentCompatibility(ItemStack stack, Enchantment ench)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnchantmentType",
+          "sig": "EnchantmentCategory getEnchantmentType(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isBookEnchantable",
+          "sig": "boolean isBookEnchantable(ItemStack stack, ItemStack book)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IForgeItem"
+      ],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IElectricItem",
+      "methods": [
+        {
+          "name": "canProvideEnergy",
+          "sig": "boolean canProvideEnergy(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCapacity",
+          "sig": "int getCapacity(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTier",
+          "sig": "int getTier(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTransferLimit",
+          "sig": "int getTransferLimit(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IElectricItemManager",
+      "methods": [
+        {
+          "name": "charge",
+          "sig": "int charge(ItemStack stack, int amount, int tier, boolean ignoreTransferLimit, boolean simulate)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "discharge",
+          "sig": "int discharge(ItemStack stack, int amount, int tier, boolean ignoreTransferLimit, boolean externally, boolean simulate)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCharge",
+          "sig": "int getCharge(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCapacity",
+          "sig": "int getCapacity(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canUse",
+          "sig": "boolean canUse(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "use",
+          "sig": "boolean use(ItemStack stack, int amount, LivingEntity entity)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "chargeFromArmor",
+          "sig": "void chargeFromArmor(ItemStack stack, LivingEntity entity)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTier",
+          "sig": "int getTier(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTransferLimit",
+          "sig": "int getTransferLimit(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getToolTip",
+          "sig": "Component getToolTip(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IFluidScanner",
+      "methods": [
+        {
+          "name": "getScanRadius",
+          "sig": "int getScanRadius(ItemStack stack, boolean useEnergy)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isValuableFluid",
+          "sig": "boolean isValuableFluid(ItemStack stack, FluidState state, LevelReader world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isValuableFluid",
+          "sig": "boolean isValuableFluid(ItemStack stack, FluidState state)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IMiningDrill",
+      "methods": [
+        {
+          "name": "canMineBlock",
+          "sig": "boolean canMineBlock(ItemStack drill, BlockState state, LevelReader access, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMiningBoost",
+          "sig": "int getMiningBoost(ItemStack stack, BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExtraEnergyCost",
+          "sig": "int getExtraEnergyCost(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canDrillBeUsed",
+          "sig": "boolean canDrillBeUsed(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onDrillUsed",
+          "sig": "void onDrillUsed(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.electric.IScanner",
+      "methods": [
+        {
+          "name": "getScanRadius",
+          "sig": "int getScanRadius(ItemStack stack, boolean useEnergy)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasScanEffect",
+          "sig": "boolean hasScanEffect(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isOreValuable",
+          "sig": "boolean isOreValuable(ItemStack stack, BlockState state, LevelReader world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isOreValuable",
+          "sig": "boolean isOreValuable(ItemStack stack, BlockState state)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOreValue",
+          "sig": "int getOreValue(ItemStack stack, BlockState state, LevelReader world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOreValue",
+          "sig": "int getOreValue(ItemStack stack, BlockState state)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.readers.ICropReader",
+      "methods": [
+        {
+          "name": "isCropReader",
+          "sig": "boolean isCropReader(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isCropReaderImpl",
+          "sig": "boolean isCropReaderImpl(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.readers.IEUReader",
+      "methods": [
+        {
+          "name": "isEUReader",
+          "sig": "boolean isEUReader(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isEUReaderImpl",
+          "sig": "boolean isEUReaderImpl(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.readers.IThermometer",
+      "methods": [
+        {
+          "name": "isThermometer",
+          "sig": "boolean isThermometer(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isThermometerImpl",
+          "sig": "boolean isThermometerImpl(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.items.readers.IWrenchTool",
+      "methods": [
+        {
+          "name": "getActualLoss",
+          "sig": "double getActualLoss(ItemStack stack, double originalLoss)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "shouldRenderOverlay",
+          "sig": "boolean shouldRenderOverlay(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.network.INetworkManager",
+      "methods": [
+        {
+          "name": "registerDataBuffer",
+          "sig": "void registerDataBuffer(ResourceLocation location, Class<INetworkDataBuffer> clz, Supplier<INetworkDataBuffer> creator)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "startGuiTracking",
+          "sig": "void startGuiTracking(BlockEntity tile, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendInitialGuiData",
+          "sig": "void sendInitialGuiData(INetworkFieldProvider tile, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateGuiData",
+          "sig": "void updateGuiData(BlockEntity tile, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateTileField",
+          "sig": "void updateTileField(BlockEntity tile, String field)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateTileFields",
+          "sig": "void updateTileFields(BlockEntity tile, String... fields)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateGuiField",
+          "sig": "void updateGuiField(BlockEntity tile, String field)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateGuiFields",
+          "sig": "void updateGuiFields(BlockEntity tile, String... fields)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendInitialData",
+          "sig": "void sendInitialData(INetworkFieldProvider prov, CompoundTag nbt)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "handleInitialChange",
+          "sig": "void handleInitialChange(BlockEntity prov, CompoundTag nbt)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "requestInitialData",
+          "sig": "void requestInitialData(INetworkFieldProvider prov)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendTileEvent",
+          "sig": "void sendTileEvent(BlockEntity tile, int key, int value, PacketRange target)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendTileDataBufferEvent",
+          "sig": "void sendTileDataBufferEvent(BlockEntity tile, String id, INetworkDataBuffer buffer, PacketRange target)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendClientTileEvent",
+          "sig": "void sendClientTileEvent(BlockEntity tile, int key, int value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendClientTileDataBufferEvent",
+          "sig": "void sendClientTileDataBufferEvent(BlockEntity tile, String id, INetworkDataBuffer buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendItemEvent",
+          "sig": "void sendItemEvent(Player player, ItemStack stack, int key, int value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendItemBuffer",
+          "sig": "void sendItemBuffer(Player player, ItemStack stack, String id, INetworkDataBuffer buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendClientItemEvent",
+          "sig": "void sendClientItemEvent(ItemStack stack, int key, int value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "sendClientItemBuffer",
+          "sig": "void sendClientItemBuffer(ItemStack stack, String id, INetworkDataBuffer buffer)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.IPlayerPacket",
+      "methods": [
+        {
+          "name": "getContainer",
+          "sig": "T getContainer(Player player, Class<T> clz)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getContainer",
+          "sig": "void getContainer(Player player, Class<T> clz, Consumer<T> listener)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOptionalContainer",
+          "sig": "Optional<T> getOptionalContainer(Player player, Class<T> clz)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "findPlayerStack",
+          "sig": "ItemStack findPlayerStack(Player player, ItemStack send)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.buffer.IBitLevelOverride",
+      "methods": [
+        {
+          "name": "getOverride",
+          "sig": "BitLevel getOverride(int fieldID, String fieldName)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasOverride",
+          "sig": "boolean hasOverride(int fieldID, String fieldName)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.buffer.IInputBuffer",
+      "methods": [
+        {
+          "name": "readBoolean",
+          "sig": "boolean readBoolean()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readByte",
+          "sig": "byte readByte()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readShort",
+          "sig": "short readShort()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readMedium",
+          "sig": "int readMedium()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readInt",
+          "sig": "int readInt()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readVarInt",
+          "sig": "int readVarInt()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readFloat",
+          "sig": "float readFloat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readDouble",
+          "sig": "double readDouble()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readLong",
+          "sig": "long readLong()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readData",
+          "sig": "long readData(BitLevel length)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readChar",
+          "sig": "char readChar()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readEnum",
+          "sig": "T readEnum(Class<T> clz)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readBytes",
+          "sig": "byte[] readBytes()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readString",
+          "sig": "String readString()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readNBTData",
+          "sig": "CompoundTag readNBTData()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readForgeRegistryEntry",
+          "sig": "T readForgeRegistryEntry(IForgeRegistry<T> registry)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readItemStack",
+          "sig": "ItemStack readItemStack()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readFluidStack",
+          "sig": "FluidStack readFluidStack()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readUUID",
+          "sig": "UUID readUUID()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readRegistryKey",
+          "sig": "ResourceKey<T> readRegistryKey(ResourceKey<Registry<T>> key)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.buffer.INetworkDataBuffer",
+      "methods": [
+        {
+          "name": "write",
+          "sig": "void write(IOutputBuffer buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "read",
+          "sig": "void read(IInputBuffer buffer)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.buffer.IOutputBuffer",
+      "methods": [
+        {
+          "name": "writeBoolean",
+          "sig": "void writeBoolean(boolean value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeByte",
+          "sig": "void writeByte(byte value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeShort",
+          "sig": "void writeShort(short value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeMedium",
+          "sig": "void writeMedium(int value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeInt",
+          "sig": "void writeInt(int value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeVarInt",
+          "sig": "void writeVarInt(int value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeFloat",
+          "sig": "void writeFloat(float value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeDouble",
+          "sig": "void writeDouble(double value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeLong",
+          "sig": "void writeLong(long value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeData",
+          "sig": "void writeData(long value, BitLevel type)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeChar",
+          "sig": "void writeChar(char value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeEnum",
+          "sig": "void writeEnum(Enum<?> value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeString",
+          "sig": "void writeString(String value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeBytes",
+          "sig": "void writeBytes(byte[] value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeNBTData",
+          "sig": "void writeNBTData(CompoundTag value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeForgeEntry",
+          "sig": "void writeForgeEntry(T value, IForgeRegistry<T> registry)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeItemStack",
+          "sig": "void writeItemStack(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeFluidStack",
+          "sig": "void writeFluidStack(FluidStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeUUID",
+          "sig": "void writeUUID(UUID value)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeRegistryKey",
+          "sig": "void writeRegistryKey(ResourceKey<?> key)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeItemStack",
+          "sig": "void writeItemStack(ItemStack stack, IOutputBuffer buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeEnum",
+          "sig": "void writeEnum(Enum<?> value, IOutputBuffer buffer)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.container.IContainerDataEvent",
+      "methods": [
+        {
+          "name": "onDataReceived",
+          "sig": "void onDataReceived(int key, int value)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.item.INetworkItemBufferEvent",
+      "methods": [
+        {
+          "name": "onDataBufferReceived",
+          "sig": "void onDataBufferReceived(ItemStack stack, Player player, String id, T buffer, Dist targetSide)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IPlayerPacket"
+      ],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.item.INetworkItemEvent",
+      "methods": [
+        {
+          "name": "onEventReceived",
+          "sig": "void onEventReceived(ItemStack stack, Player player, int key, int value, Dist target)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IPlayerPacket"
+      ],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.tile.INetworkClientEventListener",
+      "methods": [
+        {
+          "name": "onClientDataReceived",
+          "sig": "void onClientDataReceived(Player entity, int key, int value)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IPlayerPacket"
+      ],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.tile.INetworkDataEventListener",
+      "methods": [
+        {
+          "name": "onDataBufferReceived",
+          "sig": "void onDataBufferReceived(Player player, String id, INetworkDataBuffer data, Dist target)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IPlayerPacket"
+      ],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.tile.INetworkEventListener",
+      "methods": [
+        {
+          "name": "onServerDataReceived",
+          "sig": "void onServerDataReceived(int key, int value)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.tile.INetworkFieldNotifier",
+      "methods": [
+        {
+          "name": "onNetworkFieldChanged",
+          "sig": "void onNetworkFieldChanged(Set<String> fields, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onGuiFieldChanged",
+          "sig": "void onGuiFieldChanged(Set<String> fields, Player player)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IPlayerPacket"
+      ],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.network.tile.INetworkFieldProvider",
+      "methods": [
+        {
+          "name": "getNetworkFields",
+          "sig": "List<String> getNetworkFields()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGuiFields",
+          "sig": "List<String> getGuiFields()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isDefaultData",
+          "sig": "boolean isDefaultData(String fieldName)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IChamberReactor",
+      "methods": [
+        {
+          "name": "refreshChambers",
+          "sig": "void refreshChambers()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getWidth",
+          "sig": "int getWidth()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHeight",
+          "sig": "int getHeight()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IReactor"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IReactor",
+      "methods": [
+        {
+          "name": "getHeat",
+          "sig": "int getHeat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setHeat",
+          "sig": "void setHeat(int newHeat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addHeat",
+          "sig": "void addHeat(int heat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxHeat",
+          "sig": "int getMaxHeat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setMaxHeat",
+          "sig": "void setMaxHeat(int heat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHeatEffectModifier",
+          "sig": "float getHeatEffectModifier()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setHeatEffectModifier",
+          "sig": "void setHeatEffectModifier(float hem)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnergyOutput",
+          "sig": "double getEnergyOutput()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addOutput",
+          "sig": "void addOutput(float output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStackInReactor",
+          "sig": "ItemStack getStackInReactor(int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setStackInReactor",
+          "sig": "void setStackInReactor(int x, int y, ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "explode",
+          "sig": "void explode()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTickRate",
+          "sig": "int getTickRate()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isProducingEnergy",
+          "sig": "boolean isProducingEnergy()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ILocation"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IReactorChamber",
+      "methods": [
+        {
+          "name": "getReactor",
+          "sig": "IReactor getReactor()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IReactorComponent",
+      "methods": [
+        {
+          "name": "isValidForReactor",
+          "sig": "boolean isValidForReactor(ItemStack stack, IReactor reactor)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "processChamber",
+          "sig": "void processChamber(ItemStack stack, IReactor reactor, int x, int y, boolean heatCalculation, boolean damageTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "acceptUraniumPulse",
+          "sig": "boolean acceptUraniumPulse(ItemStack stack, IReactor reactor, ItemStack source, int myX, int myY, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canStoreHeat",
+          "sig": "boolean canStoreHeat(ItemStack stack, IReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStoredHeat",
+          "sig": "int getStoredHeat(ItemStack stack, IReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxStoredHeat",
+          "sig": "int getMaxStoredHeat(ItemStack stack, IReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "storeHeat",
+          "sig": "int storeHeat(ItemStack stack, IReactor reactor, int x, int y, int heatChange)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExplosionInfluence",
+          "sig": "float getExplosionInfluence(ItemStack stack, IReactor reactor)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IReactorProduct"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IReactorPlannerComponent",
+      "methods": [
+        {
+          "name": "applyStackSize",
+          "sig": "ItemStack applyStackSize(ItemStack newStack, int size)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStackSize",
+          "sig": "int getStackSize(ItemStack input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "provideComponents",
+          "sig": "void provideComponents(NonNullList<ItemStack> list)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getComponentID",
+          "sig": "short getComponentID(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "createSimulationComponent",
+          "sig": "SimulatedStack createSimulationComponent(ItemStack self)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addToolTip",
+          "sig": "void addToolTip(ItemStack stack, Consumer<Component> tooltips)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addAffectedSlots",
+          "sig": "void addAffectedSlots(int x, int y, BiPredicate<Integer, Integer> slots)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSupportedReactor",
+          "sig": "ReactorType getSupportedReactor(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getType",
+          "sig": "ComponentType getType(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStats",
+          "sig": "List<ReactorStat> getStats(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getReactorStat",
+          "sig": "NumericTag getReactorStat(ReactorStat stat, ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getReactorStat",
+          "sig": "NumericTag getReactorStat(ReactorStat stat, ItemStack stack, IReactor planner, int x, int y)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "FORMAT",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "NULL_VALUE",
+          "value": "valueOf()",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [
+        "IReactorComponent"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IReactorProduct",
+      "methods": [
+        {
+          "name": "isValidForReactor",
+          "sig": "boolean isValidForReactor(ItemStack stack, IReactor reactor)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.ISteamReactor",
+      "methods": [
+        {
+          "name": "getWaterTank",
+          "sig": "FluidTank getWaterTank()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSteamTank",
+          "sig": "FluidTank getSteamTank()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IReactor"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.ISteamReactorChamber",
+      "methods": [],
+      "constants": [],
+      "related": [
+        "IReactorChamber"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.IUsableUranium",
+      "methods": [
+        {
+          "name": "createDepletedUraniumRod",
+          "sig": "ItemStack createDepletedUraniumRod()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.planner.ISimulatedReactor",
+      "methods": [
+        {
+          "name": "getItem",
+          "sig": "SimulatedStack getItem(int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "markBroken",
+          "sig": "void markBroken(int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addBreedingPulse",
+          "sig": "void addBreedingPulse()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addFuelPulse",
+          "sig": "void addFuelPulse()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHeat",
+          "sig": "int getHeat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setHeat",
+          "sig": "void setHeat(int newHeat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addHeat",
+          "sig": "void addHeat(int heat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxHeat",
+          "sig": "int getMaxHeat()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setMaxHeat",
+          "sig": "void setMaxHeat(int heat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHeatEffectModifier",
+          "sig": "float getHeatEffectModifier()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setHeatEffectModifier",
+          "sig": "void setHeatEffectModifier(float hem)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addOutput",
+          "sig": "void addOutput(float output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEnergyOutput",
+          "sig": "float getEnergyOutput()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSteam",
+          "sig": "void addSteam(int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "consumeWater",
+          "sig": "int consumeWater(int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isProducingEnergy",
+          "sig": "boolean isProducingEnergy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isSteamReactor",
+          "sig": "boolean isSteamReactor()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isSimulatingPulses",
+          "sig": "boolean isSimulatingPulses()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGameTime",
+          "sig": "long getGameTime()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.planner.SimulatedStack",
+      "methods": [
+        {
+          "name": "syncStack",
+          "sig": "ItemStack syncStack(ItemStack original)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "save",
+          "sig": "CompoundTag save()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "load",
+          "sig": "void load(CompoundTag data)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "commitState",
+          "sig": "void commitState()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "reset",
+          "sig": "void reset()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "simulate",
+          "sig": "void simulate(ISimulatedReactor reactor, int x, int y, boolean heatTick, boolean damageTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "acceptUraniumPulse",
+          "sig": "boolean acceptUraniumPulse(ISimulatedReactor reactor, int x, int y, SimulatedStack source, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canStoreHeat",
+          "sig": "boolean canStoreHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStoredHeat",
+          "sig": "int getStoredHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxStoredHeat",
+          "sig": "int getMaxStoredHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "storeHeat",
+          "sig": "int storeHeat(ISimulatedReactor reactor, int x, int y, int heatChange)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canViewHeat",
+          "sig": "boolean canViewHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExplosionInfluence",
+          "sig": "float getExplosionInfluence(ISimulatedReactor reactor)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getId",
+          "sig": "short getId()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStats",
+          "sig": "List<ReactorStat> getStats()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getValidType",
+          "sig": "ReactorType getValidType()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getComponentType",
+          "sig": "ComponentType getComponentType()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStat",
+          "sig": "NumericTag getStat(ReactorStat stat)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStat",
+          "sig": "NumericTag getStat(ReactorStat stat, ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "NULL_VALUE",
+          "value": "valueOf()",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.generators.IOutputGenerator",
+      "methods": [
+        {
+          "name": "addItems",
+          "sig": "void addItems(Consumer<ItemStack> output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "JsonObject serialize()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.inputs.IInput",
+      "methods": [
+        {
+          "name": "asIngredient",
+          "sig": "Ingredient asIngredient()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getComponents",
+          "sig": "List<ItemStack> getComponents()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getInputSize",
+          "sig": "int getInputSize()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "matches",
+          "sig": "boolean matches(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "matchesAll",
+          "sig": "boolean matchesAll(ItemStack... stacks)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "matchesAny",
+          "sig": "boolean matchesAny(ItemStack... stacks)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "void serialize(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "JsonObject serialize()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeItemStack",
+          "sig": "JsonObject writeItemStack(ItemStack stack, boolean includeSize)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeFluidStack",
+          "sig": "JsonObject writeFluidStack(FluidStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readFluidStack",
+          "sig": "FluidStack readFluidStack(JsonObject obj)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readNBT",
+          "sig": "CompoundTag readNBT(String s)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "copyWithSize",
+          "sig": "ItemStack copyWithSize(ItemStack stack, int newSize)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isStackEqual",
+          "sig": "boolean isStackEqual(ItemStack key, ItemStack other)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isNBTExact",
+          "sig": "boolean isNBTExact(ItemStack subject, ItemStack target)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.inputs.INullableInput",
+      "methods": [
+        {
+          "name": "serialize",
+          "sig": "JsonObject serialize()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IInput"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.queue.IInputter",
+      "methods": [
+        {
+          "name": "addItemIntoSlot",
+          "sig": "void addItemIntoSlot(int slot, ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.queue.IStackOutput",
+      "methods": [
+        {
+          "name": "addToInventory",
+          "sig": "boolean addToInventory(IInputter inventory)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStack",
+          "sig": "ItemStack getStack()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "save",
+          "sig": "void save(CompoundTag save)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.recipes.IFluidRecipeOutput",
+      "methods": [
+        {
+          "name": "onFluidRecipeProcessed",
+          "sig": "List<FluidStack> onFluidRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, ItemStack input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onFluidRecipeProcessed",
+          "sig": "List<FluidStack> onFluidRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, ItemStack input, IRecipeOverride overrides)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllFluidOutputs",
+          "sig": "List<FluidStack> getAllFluidOutputs()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "copyFluids",
+          "sig": "List<FluidStack> copyFluids(List<FluidStack> copy)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IRecipeOutput"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.recipes.IRecipeOutput",
+      "methods": [
+        {
+          "name": "onRecipeProcessed",
+          "sig": "List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onRecipeProcessed",
+          "sig": "List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, IRecipeOverride overrides)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllOutputs",
+          "sig": "List<ItemStack> getAllOutputs()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMetadata",
+          "sig": "CompoundTag getMetadata()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExperience",
+          "sig": "float getExperience()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "void serialize(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "JsonObject serialize()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "copyItems",
+          "sig": "List<ItemStack> copyItems(List<ItemStack> copy)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "EMPTY_COMPOUND",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.recipes.IRecipeOutputChance",
+      "methods": [
+        {
+          "name": "getChance",
+          "sig": "float getChance()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IRecipeOutput"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.misc.ICanEffect",
+      "methods": [
+        {
+          "name": "onFoodEaten",
+          "sig": "void onFoodEaten(ItemStack stack, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTooltip",
+          "sig": "Component getTooltip()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOverrideIcon",
+          "sig": "TextureAtlasSprite getOverrideIcon()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getID",
+          "sig": "ResourceLocation getID()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IAdvancedCraftingManager",
+      "methods": [
+        {
+          "name": "addShapedIC2Recipe",
+          "sig": "void addShapedIC2Recipe(String location, ItemStack output, Object... args)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addShapelessIC2Recipe",
+          "sig": "void addShapelessIC2Recipe(String location, ItemStack output, Object... args)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRepairIC2Recipe",
+          "sig": "void addRepairIC2Recipe(String location, IRepairable repair, IInput repairMaterial, int effect, Object... args)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addShapedRecipe",
+          "sig": "void addShapedRecipe(ResourceLocation location, ItemStack output, Object... args)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addShapelessRecipe",
+          "sig": "void addShapelessRecipe(ResourceLocation location, ItemStack output, Object... args)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRepairRecipe",
+          "sig": "void addRepairRecipe(ResourceLocation id, IRepairable repair, IInput repairMaterial, int effect, Object... args)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeCraftingRecipe",
+          "sig": "void removeCraftingRecipe(ResourceLocation id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2SmeltingRecipe",
+          "sig": "void addIC2SmeltingRecipe(String location, ItemStack output, Object input, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2SmeltingRecipe",
+          "sig": "void addIC2SmeltingRecipe(String location, ItemStack output, Object input, float xp, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2SmeltingRecipe",
+          "sig": "void addIC2SmeltingRecipe(String location, ItemStack output, Object input, float xp, float extraTime, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSmeltingRecipe",
+          "sig": "void addSmeltingRecipe(ResourceLocation location, ItemStack output, Object input, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSmeltingRecipe",
+          "sig": "void addSmeltingRecipe(ResourceLocation location, ItemStack output, Object input, float xp, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSmeltingRecipe",
+          "sig": "void addSmeltingRecipe(ResourceLocation location, ItemStack output, Object input, float xp, float extraTime, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeSmeltingRecipe",
+          "sig": "void removeSmeltingRecipe(ResourceLocation id, SmeltingType... types)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addStoneCutterRecipe",
+          "sig": "void addStoneCutterRecipe(ResourceLocation location, ItemStack output, Object input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addStoneCutterIC2Recipe",
+          "sig": "void addStoneCutterIC2Recipe(String location, ItemStack output, Object input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeStoneCutterRecipe",
+          "sig": "void removeStoneCutterRecipe(ResourceLocation id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSmithingRecipe",
+          "sig": "void addSmithingRecipe(ResourceLocation location, Object main, Object secondary, ItemStack output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSmithingIC2Recipe",
+          "sig": "void addSmithingIC2Recipe(String location, Object main, Object secondary, ItemStack output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeSmithingRecipe",
+          "sig": "void removeSmithingRecipe(ResourceLocation id)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IAdvancedCraftingManager>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.ICannerRecipeRegistry",
+      "methods": [
+        {
+          "name": "registerRepairable",
+          "sig": "void registerRepairable(IRepairable repair, IInput input, int repairAmount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeRepairable",
+          "sig": "void removeRepairable(IRepairable repair)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRepairableItem",
+          "sig": "Tuple<IInput, Integer> getRepairableItem(ItemStack input, ItemStack repair, boolean compareStack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRepairItems",
+          "sig": "Map<Item, List<Tuple<IInput, Integer>>> getRepairItems()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerFuelValue",
+          "sig": "void registerFuelValue(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerFuelMultiplier",
+          "sig": "void registerFuelMultiplier(ItemStack stack, float multiplier)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeValue",
+          "sig": "void removeValue(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getValueForStack",
+          "sig": "FuelValue getValueForStack(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFuels",
+          "sig": "List<FuelValue> getFuels()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerFillable",
+          "sig": "void registerFillable(ItemStack container, IInput fillable, ItemStack output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasContainer",
+          "sig": "boolean hasContainer(ItemStack container)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeFillable",
+          "sig": "void removeFillable(ItemStack container)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeFillable",
+          "sig": "void removeFillable(ItemStack container, ItemStack fillable)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFillOutput",
+          "sig": "Tuple<IInput, ItemStack> getFillOutput(ItemStack container, ItemStack toFill, boolean compareStack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFillables",
+          "sig": "Map<ItemStack, List<Tuple<IInput, ItemStack>>> getFillables()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<ICannerRecipeRegistry>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IElectrolyzerRecipeList",
+      "methods": [
+        {
+          "name": "addChargeRecipe",
+          "sig": "void addChargeRecipe(ResourceLocation id, ItemStack input, ItemStack output, int energy)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addDischargeRecipe",
+          "sig": "void addDischargeRecipe(ResourceLocation id, ItemStack input, ItemStack output, int energy)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addDualRecipe",
+          "sig": "void addDualRecipe(ResourceLocation id, ItemStack input, ItemStack output, int energy)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRecipe",
+          "sig": "void addRecipe(ResourceLocation id, ItemStack input, ItemStack output, int flags, int energy)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeRecipe",
+          "sig": "void removeRecipe(ItemStack input, boolean charge)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeRecipe",
+          "sig": "void removeRecipe(ResourceLocation id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipes",
+          "sig": "List<ElectrolyzerRecipe> getRecipes()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "ElectrolyzerRecipe getRecipe(ItemStack input, boolean charge, boolean compareSize)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "CHARGE",
+          "value": "1",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "DISCHARGE",
+          "value": "2",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [
+        "IListenableRegistry<IElectrolyzerRecipeList>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IFluidFuelRegistry",
+      "methods": [
+        {
+          "name": "addFuel",
+          "sig": "void addFuel(Fluid fluid, int ticksPerBucket, int euPerTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeFuel",
+          "sig": "void removeFuel(Fluid fluid)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFuels",
+          "sig": "List<FuelEntry> getFuels()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFuel",
+          "sig": "FuelEntry getFuel(Fluid fluid)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IFluidFuelRegistry>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IFoodCanRegistry",
+      "methods": [
+        {
+          "name": "registerEffect",
+          "sig": "Item registerEffect(ICanEffect effect)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEffect",
+          "sig": "ICanEffect getEffect(ResourceLocation location)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllEffects",
+          "sig": "List<ResourceLocation> getAllEffects()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEffectItem",
+          "sig": "Item getEffectItem(ResourceLocation item)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerItemForEffect",
+          "sig": "void registerItemForEffect(ItemStack stack, ResourceLocation location)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEffectForFood",
+          "sig": "ResourceLocation getEffectForFood(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getItemForFood",
+          "sig": "Item getItemForFood(ItemStack food)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IFusionRecipeList",
+      "methods": [
+        {
+          "name": "addFuel",
+          "sig": "void addFuel(Item fuel, int fuelValue, float productionRate, boolean consumed)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFuel",
+          "sig": "FusionFuel getFuel(Item item)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeFuel",
+          "sig": "void removeFuel(Item item)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFuels",
+          "sig": "List<FusionFuel> getFuels()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "FusionFuel",
+          "sig": "record FusionFuel(Item fuel, int fuelValue, float productionRate, boolean consumed)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IFusionRecipeList>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IIngredientRegistry",
+      "methods": [
+        {
+          "name": "registerInput",
+          "sig": "void registerInput(ResourceLocation location, Class<IInput> clz, Function<FriendlyByteBuf, IInput> creator, Function<JsonObject, IInput> serializer, Function<Object, IInput> maker)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerRecipeOutput",
+          "sig": "void registerRecipeOutput(ResourceLocation location, Class<IRecipeOutput> clz, Function<FriendlyByteBuf, IRecipeOutput> creator, Function<JsonObject, IRecipeOutput> serializer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerFluidOutput",
+          "sig": "void registerFluidOutput(ResourceLocation location, Class<IFluidRecipeOutput> clz, Function<FriendlyByteBuf, IFluidRecipeOutput> creator, Function<JsonObject, IFluidRecipeOutput> serializer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerQueue",
+          "sig": "void registerQueue(ResourceLocation location, Class<IStackOutput> clz, Function<CompoundTag, IStackOutput> creator)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerOutputGenerators",
+          "sig": "void registerOutputGenerators(ResourceLocation location, Class<IOutputGenerator> clz, Function<JsonObject, IOutputGenerator> creator)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeInput",
+          "sig": "void writeInput(IInput input, FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeRecipeOutput",
+          "sig": "void writeRecipeOutput(IRecipeOutput output, FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeFluidOutput",
+          "sig": "void writeFluidOutput(IFluidRecipeOutput output, FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "writeQueue",
+          "sig": "CompoundTag writeQueue(IStackOutput queue)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readInput",
+          "sig": "IInput readInput(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "createOutput",
+          "sig": "IRecipeOutput createOutput(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "createFluidOutput",
+          "sig": "IFluidRecipeOutput createFluidOutput(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readQueue",
+          "sig": "IStackOutput readQueue(CompoundTag nbt)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readInput",
+          "sig": "IInput readInput(JsonObject obj)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readOutput",
+          "sig": "IRecipeOutput readOutput(JsonObject obj)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readFluidOutput",
+          "sig": "IFluidRecipeOutput readFluidOutput(JsonObject obj)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "readOutputGenerator",
+          "sig": "IOutputGenerator readOutputGenerator(JsonObject obj)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "createInputFrom",
+          "sig": "IInput createInputFrom(Object obj)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serializeInput",
+          "sig": "JsonObject serializeInput(IInput input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serializeOutput",
+          "sig": "JsonObject serializeOutput(IRecipeOutput output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serializeFluidOutput",
+          "sig": "JsonObject serializeFluidOutput(IFluidRecipeOutput output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serializeOutputGenerator",
+          "sig": "JsonObject serializeOutputGenerator(IOutputGenerator generator)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IListenableRegistry",
+      "methods": [
+        {
+          "name": "registerListener",
+          "sig": "void registerListener(Consumer<T> listener)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IMachineRecipeList",
+      "methods": [
+        {
+          "name": "addRecipe",
+          "sig": "void addRecipe(RecipeEntry recipe)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRecipe",
+          "sig": "void addRecipe(ResourceLocation id, IRecipeOutput output, IInput... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSimpleRecipe",
+          "sig": "void addSimpleRecipe(ResourceLocation id, ItemStack output, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addSimpleRecipe",
+          "sig": "void addSimpleRecipe(ResourceLocation id, ItemStack output, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addXPRecipe",
+          "sig": "void addXPRecipe(ResourceLocation id, ItemStack output, float xp, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addXPRecipe",
+          "sig": "void addXPRecipe(ResourceLocation id, ItemStack output, float xp, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addChanceRecipe",
+          "sig": "void addChanceRecipe(ResourceLocation id, ItemStack output, float xp, float chance, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addChanceRecipe",
+          "sig": "void addChanceRecipe(ResourceLocation id, ItemStack output, float xp, float chance, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRangeRecipe",
+          "sig": "void addRangeRecipe(ResourceLocation id, ItemStack output, int minValue, int maxValue, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRangeRecipe",
+          "sig": "void addRangeRecipe(ResourceLocation id, ItemStack output, int minValue, int maxValue, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRecipe",
+          "sig": "void addRecipe(ResourceLocation id, IRecipeOutput output, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2SimpleRecipe",
+          "sig": "void addIC2SimpleRecipe(String id, ItemStack output, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2SimpleRecipe",
+          "sig": "void addIC2SimpleRecipe(String id, ItemStack output, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2XPRecipe",
+          "sig": "void addIC2XPRecipe(String id, ItemStack output, float xp, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2XPRecipe",
+          "sig": "void addIC2XPRecipe(String id, ItemStack output, float xp, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2ChanceRecipe",
+          "sig": "void addIC2ChanceRecipe(String id, ItemStack output, float xp, float chance, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2ChanceRecipe",
+          "sig": "void addIC2ChanceRecipe(String id, ItemStack output, float xp, float chance, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2RangeRecipe",
+          "sig": "void addIC2RangeRecipe(String id, ItemStack output, int minValue, int maxValue, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2RangeRecipe",
+          "sig": "void addIC2RangeRecipe(String id, ItemStack output, int minValue, int maxValue, CompoundTag data, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addIC2Recipe",
+          "sig": "void addIC2Recipe(String id, IRecipeOutput output, Object... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasRecipeForItem",
+          "sig": "boolean hasRecipeForItem(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "RecipeEntry getRecipe(ResourceLocation location)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "RecipeEntry getRecipe(ItemStack stack, boolean hasStackSize)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "RecipeEntry getRecipe(Predicate<RecipeEntry> checker)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeRecipe",
+          "sig": "RecipeEntry removeRecipe(ResourceLocation location)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllRecipes",
+          "sig": "List<ResourceLocation> getAllRecipes()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllEntries",
+          "sig": "List<RecipeEntry> getAllEntries()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "convertInputs",
+          "sig": "IInput[] convertInputs(Object... inputs)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IMachineRecipeList>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IPotionBrewRegistry",
+      "methods": [
+        {
+          "name": "registerBrew",
+          "sig": "void registerBrew(Item item, MobEffect potion)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerBrew",
+          "sig": "void registerBrew(Item item, MobEffect fromEffect, MobEffect toEffect)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeBrew",
+          "sig": "void removeBrew(Item item)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEffect",
+          "sig": "MobEffect getEffect(Item item, MobEffect original)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEffects",
+          "sig": "Map<Item, Map<MobEffect, MobEffect>> getEffects()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRequiredItems",
+          "sig": "List<Item> getRequiredItems(MobEffect desiredEffect)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerName",
+          "sig": "void registerName(MobEffect effect, String name)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getName",
+          "sig": "String getName(MobEffect effect)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerPotionContainer",
+          "sig": "void registerPotionContainer(Item input, PotionContainer output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getPotionContainer",
+          "sig": "PotionContainer getPotionContainer(Item input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getContainers",
+          "sig": "Map<Item, PotionContainer> getContainers()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IPotionBrewRegistry>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IRareEarthRegistry",
+      "methods": [
+        {
+          "name": "registerOutput",
+          "sig": "void registerOutput(ResourceLocation id, ItemStack output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerInput",
+          "sig": "void registerInput(ResourceLocation id, float value, ItemStack... input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOutputFor",
+          "sig": "RareEntry getOutputFor(ItemStack input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOutputFor",
+          "sig": "ItemStack getOutputFor(ResourceLocation id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeInput",
+          "sig": "RareEntry removeInput(ItemStack input)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeOutput",
+          "sig": "void removeOutput(ItemStack output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "remove",
+          "sig": "void remove(ResourceLocation id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllRecipes",
+          "sig": "List<RareEntry> getAllRecipes()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IRareEarthRegistry>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IRecipeFilter",
+      "methods": [
+        {
+          "name": "add",
+          "sig": "void add(ItemLike... items)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "add",
+          "sig": "void add(IInput... inputs)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "remove",
+          "sig": "void remove(ItemStack stack, int flags)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "contains",
+          "sig": "boolean contains(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFilteredItems",
+          "sig": "List<ItemStack> getFilteredItems()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "clear",
+          "sig": "void clear()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "JsonObject serialize()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "read",
+          "sig": "void read(JsonObject obj)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "SIMPLE",
+          "value": "1",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "FILTER",
+          "value": "2",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "BOTH",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IRecyclerRecipeList",
+      "methods": [
+        {
+          "name": "getBlackList",
+          "sig": "IRecipeFilter getBlackList()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IMachineRecipeList"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IRefiningRecipeList",
+      "methods": [
+        {
+          "name": "addIC2Recipe",
+          "sig": "Builder addIC2Recipe(String id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRecipe",
+          "sig": "Builder addRecipe(ResourceLocation id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addRecipe",
+          "sig": "void addRecipe(ResourceLocation location, FluidStack input, FluidStack secondInput, IInput catalyst, IFluidRecipeOutput output)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "FluidRecipe getRecipe(ResourceLocation location)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "FluidRecipe getRecipe(ItemStack item, FluidStack firstTank, FluidStack secondTank, boolean testAmounts)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRecipe",
+          "sig": "FluidRecipe getRecipe(Predicate<FluidRecipe> checker)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeRecipe",
+          "sig": "FluidRecipe removeRecipe(ResourceLocation location, boolean includeInverted)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllRecipes",
+          "sig": "List<FluidRecipe> getAllRecipes()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isValidCatalyst",
+          "sig": "boolean isValidCatalyst(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isValidFirstFluid",
+          "sig": "boolean isValidFirstFluid(FluidStack fluid)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isValidSecondFluid",
+          "sig": "boolean isValidSecondFluid(FluidStack fluid)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IRefiningRecipeList>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IScrapBoxRegistry",
+      "methods": [
+        {
+          "name": "addDrop",
+          "sig": "void addDrop(ItemLike prov, float chance)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addDrop",
+          "sig": "void addDrop(ItemStack stack, float chance)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRandomDrop",
+          "sig": "IDrop getRandomDrop(ItemStack source, boolean consumeItem)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeDrops",
+          "sig": "void removeDrops(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeDrop",
+          "sig": "void removeDrop(IDrop drop)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAllDrops",
+          "sig": "List<IDrop> getAllDrops()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IScrapBoxRegistry>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.registries.IUUMatterRegistry",
+      "methods": [
+        {
+          "name": "registerUUShape",
+          "sig": "void registerUUShape(UUMatterBuilder builder)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerUUEntry",
+          "sig": "void registerUUEntry(ItemStack output, int milliUU)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEntries",
+          "sig": "List<UUMatterEntry> getEntries()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeUUEntry",
+          "sig": "void removeUUEntry(UUMatterEntry entry)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IListenableRegistry<IUUMatterRegistry>"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.ticks.ITickScheduler",
+      "methods": [
+        {
+          "name": "addWorldCallback",
+          "sig": "void addWorldCallback(Level world, ToIntFunction<Level> ticket)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addWorldCallback",
+          "sig": "void addWorldCallback(Level world, ToIntFunction<Level> ticket, int delay)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addServerCallback",
+          "sig": "void addServerCallback(ToIntFunction<MinecraftServer> ticket)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addServerCallback",
+          "sig": "void addServerCallback(ToIntFunction<MinecraftServer> ticket, int delay)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addClientCallback",
+          "sig": "void addClientCallback(IntSupplier ticket)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addClientCallback",
+          "sig": "void addClientCallback(IntSupplier ticket, int delay)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IAnchorTile",
+      "methods": [
+        {
+          "name": "hasAnchor",
+          "sig": "boolean hasAnchor(Direction side)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addAnchor",
+          "sig": "boolean addAnchor(Direction side)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "removeAnchor",
+          "sig": "boolean removeAnchor(Direction side)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.ICopyableSettings",
+      "methods": [
+        {
+          "name": "saveSettings",
+          "sig": "void saveSettings(CompoundTag compound)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "loadSettings",
+          "sig": "void loadSettings(CompoundTag compound)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IElectrolyzerProvider",
+      "methods": [
+        {
+          "name": "getProcessRate",
+          "sig": "int getProcessRate()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEnergyStorage"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IEnergyStorage",
+      "methods": [
+        {
+          "name": "addEnergy",
+          "sig": "int addEnergy(int power)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "drawEnergy",
+          "sig": "int drawEnergy(int power)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IEUStorage"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IFluidMachine",
+      "methods": [
+        {
+          "name": "getConnectedTank",
+          "sig": "IFluidHandler getConnectedTank(Direction dir)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IInputMachine",
+      "methods": [
+        {
+          "name": "getValidRoom",
+          "sig": "int getValidRoom(ItemStack stack)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IMachine",
+      "methods": [
+        {
+          "name": "getSupportedUpgradeTypes",
+          "sig": "EnumSet<UpgradeType> getSupportedUpgradeTypes()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onUpgradesChanged",
+          "sig": "void onUpgradesChanged()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAvailableEnergy",
+          "sig": "int getAvailableEnergy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "useEnergy",
+          "sig": "boolean useEnergy(int toUse, boolean doUse)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isMachineWorking",
+          "sig": "boolean isMachineWorking()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setRedstoneSensitive",
+          "sig": "void setRedstoneSensitive(boolean flag)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isRedstoneSensitive",
+          "sig": "boolean isRedstoneSensitive()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getConnectedInventory",
+          "sig": "IItemHandler getConnectedInventory(Direction dir)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getConnectedTube",
+          "sig": "ITube getConnectedTube(Direction dir)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ILocation",
+        "IInputMachine"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.INotifiableMachine",
+      "methods": [
+        {
+          "name": "onNotify",
+          "sig": "void onNotify()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.IRecipeMachine",
+      "methods": [
+        {
+          "name": "getRecipeList",
+          "sig": "IMachineRecipeList getRecipeList()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IInputMachine"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.ITerraformer",
+      "methods": [
+        {
+          "name": "getBiome",
+          "sig": "Holder<Biome> getBiome(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setBiome",
+          "sig": "boolean setBiome(Level world, BlockPos pos, ResourceLocation biomeKey)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFirstSolidBlockFrom",
+          "sig": "BlockPos getFirstSolidBlockFrom(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFirstBlockFrom",
+          "sig": "BlockPos getFirstBlockFrom(Level world, BlockPos pos)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "switchGround",
+          "sig": "boolean switchGround(Level world, BlockPos pos, BlockState from, BlockState to, boolean upwards, boolean stateCompare)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ILocation"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.display.IDisplayInfo",
+      "methods": [
+        {
+          "name": "render",
+          "sig": "void render(PoseStack stack, int x, int y, int width, int height, Alignment align, IMonitorRenderer helper)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHeight",
+          "sig": "int getHeight(int width, Alignment align)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isValid",
+          "sig": "boolean isValid()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "void serialize(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getServerData",
+          "sig": "Tag getServerData()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "REGISTRY",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.display.IDisplayRegistry",
+      "methods": [
+        {
+          "name": "register",
+          "sig": "void register(ResourceLocation id, Class<IDisplayInfo> info, Function<FriendlyByteBuf, IDisplayInfo> creator)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "serialize",
+          "sig": "void serialize(IDisplayInfo info, FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "deserialize",
+          "sig": "IDisplayInfo deserialize(FriendlyByteBuf buffer)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.display.IMonitorRenderer",
+      "methods": [
+        {
+          "name": "getBatcher",
+          "sig": "MultiBufferSource getBatcher()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFont",
+          "sig": "Font getFont()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getItemRenderer",
+          "sig": "ItemRenderer getItemRenderer()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "renderGuiItems",
+          "sig": "void renderGuiItems(PoseStack matrix, ItemStack stack, float x, float y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "renderGuiItemText",
+          "sig": "void renderGuiItemText(PoseStack matrixstack, ItemStack stack, float x, float y, String text)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "renderGuiItemText",
+          "sig": "void renderGuiItemText(PoseStack matrixstack, Font font, ItemStack stack, float x, float y, String text)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IActivityProvider",
+      "methods": [
+        {
+          "name": "isActivated",
+          "sig": "boolean isActivated()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IAirSpeed",
+      "methods": [
+        {
+          "name": "getCurrentSpeed",
+          "sig": "float getCurrentSpeed()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxSpeed",
+          "sig": "float getMaxSpeed()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IEUProducer",
+      "methods": [
+        {
+          "name": "getEUProduction",
+          "sig": "float getEUProduction()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IEUStorage",
+      "methods": [
+        {
+          "name": "getStoredEU",
+          "sig": "int getStoredEU()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxEU",
+          "sig": "int getMaxEU()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTier",
+          "sig": "int getTier()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getChargeLevel",
+          "sig": "double getChargeLevel()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IFuelStorage",
+      "methods": [
+        {
+          "name": "getFuel",
+          "sig": "int getFuel()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxFuel",
+          "sig": "int getMaxFuel()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IProgressMachine",
+      "methods": [
+        {
+          "name": "getProgress",
+          "sig": "float getProgress()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxProgress",
+          "sig": "float getMaxProgress()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IPumpTile",
+      "methods": [
+        {
+          "name": "getPumpProgress",
+          "sig": "int getPumpProgress()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getPumpMaxProgress",
+          "sig": "int getPumpMaxProgress()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.ISpeedMachine",
+      "methods": [
+        {
+          "name": "getSpeed",
+          "sig": "int getSpeed()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxSpeed",
+          "sig": "int getMaxSpeed()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.ISubProgressMachine",
+      "methods": [
+        {
+          "name": "getSubProgress",
+          "sig": "float getSubProgress()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxSubProgress",
+          "sig": "float getMaxSubProgress()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.readers.IWorkProvider",
+      "methods": [
+        {
+          "name": "isWorking",
+          "sig": "boolean isWorking()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.teleporter.ITeleporterTarget",
+      "methods": [
+        {
+          "name": "getFacing",
+          "sig": "Direction getFacing()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSendType",
+          "sig": "TeleportType getSendType()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canReceive",
+          "sig": "boolean canReceive(TeleportType type)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "setTarget",
+          "sig": "boolean setTarget(TeleporterTarget target)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasTarget",
+          "sig": "boolean hasTarget(TeleporterTarget target)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ILocation"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.tubes.IItemCache",
+      "methods": [
+        {
+          "name": "getCache",
+          "sig": "IItemCache getCache()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getItem",
+          "sig": "Supplier<ItemStack> getItem(int id)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerItem",
+          "sig": "int registerItem(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "updateCache",
+          "sig": "void updateCache()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "clearCache",
+          "sig": "void clearCache()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "CACHE",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.tubes.ILimiterTube",
+      "methods": [
+        {
+          "name": "getValidColors",
+          "sig": "EnumSet<DyeColor> getValidColors()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ITube"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.tubes.IProviderTube",
+      "methods": [
+        {
+          "name": "provideItems",
+          "sig": "int provideItems(ItemStack stack, int amount, DyeColor color, UUID requestId)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getItemsProvided",
+          "sig": "void getItemsProvided(ObjIntConsumer<ItemStack> listener)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getProviderSource",
+          "sig": "long getProviderSource()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ITube"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.tubes.IRequestTube",
+      "methods": [
+        {
+          "name": "provideRequests",
+          "sig": "void provideRequests(ITubeRequester requested)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onRequestsReset",
+          "sig": "void onRequestsReset()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onRequestFulfilled",
+          "sig": "void onRequestFulfilled(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRequestId",
+          "sig": "UUID getRequestId()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onRequestLost",
+          "sig": "void onRequestLost(ItemStack stack, int amount)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRequestSource",
+          "sig": "long getRequestSource()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ITube"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.tiles.tubes.ITube",
+      "methods": [
+        {
+          "name": "addItem",
+          "sig": "void addItem(ItemStack item, Direction side)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addItem",
+          "sig": "void addItem(ItemStack item, Direction side, DyeColor color)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addItem",
+          "sig": "void addItem(TransportedItem item, Direction side)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canAddItem",
+          "sig": "boolean canAddItem(TransportedItem item, Direction side)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canConnect",
+          "sig": "boolean canConnect(ITube other, Direction dir)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTubeType",
+          "sig": "TubeType getTubeType()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "ILocation"
+      ],
+      "domain": "tiles"
+    },
+    {
+      "fqcn": "ic2.api.util.ILocation",
+      "methods": [
+        {
+          "name": "getWorldObj",
+          "sig": "Level getWorldObj()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getPosition",
+          "sig": "BlockPos getPosition()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [],
+      "domain": "other"
+    }
+  ],
+  "abstract_classes": [
+    {
+      "fqcn": "ic2.api.blocks.wrench.BaseWrenchHandler",
+      "methods": [
+        {
+          "name": "doSpecialAction",
+          "sig": "boolean doSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasSpecialAction",
+          "sig": "AABB hasSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canRemoveBlock",
+          "sig": "boolean canRemoveBlock(BlockState state, Level world, BlockPos pos, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDropRate",
+          "sig": "double getDropRate(BlockState state, Level world, BlockPos pos, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDrops",
+          "sig": "List<ItemStack> getDrops(BlockState state, Level world, BlockPos pos, Player player)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "IWrenchable"
+      ],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ICrop",
+      "methods": [
+        {
+          "name": "id",
+          "sig": "ResourceLocation id()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "discoveredBy",
+          "sig": "Component discoveredBy()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getName",
+          "sig": "Component getName()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDisplayItem",
+          "sig": "ItemStack getDisplayItem()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getProperties",
+          "sig": "CropProperties getProperties()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCropType",
+          "sig": "CropType getCropType()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isWaterCleaningCrop",
+          "sig": "boolean isWaterCleaningCrop(ICropTile tile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAttributes",
+          "sig": "String[] getAttributes()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTextures",
+          "sig": "List<ResourceLocation> getTextures()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowthSteps",
+          "sig": "int getGrowthSteps()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getOptimalHarvestStep",
+          "sig": "int getOptimalHarvestStep(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowthDuration",
+          "sig": "int getGrowthDuration(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStatInfluence",
+          "sig": "int getStatInfluence(ICropTile cropTile, int humidity, int nutrients, int air)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canGrow",
+          "sig": "boolean canGrow(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canBeHarvested",
+          "sig": "boolean canBeHarvested(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getAfterHarvestStage",
+          "sig": "int getAfterHarvestStage(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDropChance",
+          "sig": "double getDropChance(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDrops",
+          "sig": "ItemStack[] getDrops(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSeedDropChance",
+          "sig": "float getSeedDropChance(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSeeds",
+          "sig": "ItemStack getSeeds(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canBreed",
+          "sig": "boolean canBreed(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "isWeed",
+          "sig": "boolean isWeed(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onRightClick",
+          "sig": "boolean onRightClick(ICropTile cropTile, Player player, InteractionHand hand)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onLeftClick",
+          "sig": "boolean onLeftClick(ICropTile cropTile, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onTick",
+          "sig": "void onTick(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onBlockUpdate",
+          "sig": "void onBlockUpdate(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onEntityCollision",
+          "sig": "void onEntityCollision(ICropTile cropTile, Entity entity)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "onCropPlaceFailed",
+          "sig": "void onCropPlaceFailed(BaseSeed seed, ICropTile cropTile, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasCustomCropPlaceFailedMessage",
+          "sig": "boolean hasCustomCropPlaceFailedMessage(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCustomCropPlaceFailedMessage",
+          "sig": "Component getCustomCropPlaceFailedMessage(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canEmitRedstone",
+          "sig": "boolean canEmitRedstone(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRedstoneLevel",
+          "sig": "int getRedstoneLevel(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getEmittedLight",
+          "sig": "int getEmittedLight(ICropTile cropTile)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "desc",
+          "sig": "String desc(int i)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGrowth",
+          "sig": "int getGrowth(int combo)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getGain",
+          "sig": "int getGain(int combo)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getResistance",
+          "sig": "int getResistance(int combo)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "combineStats",
+          "sig": "short combineStats(int growth, int gain, int resistance)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "UNKNOWN",
+          "value": "translatable()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "EMPTY_DROPS",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.crops.ICropRegistry",
+      "methods": [
+        {
+          "name": "registerCustomCropRenderer",
+          "sig": "void registerCustomCropRenderer(ResourceLocation location, ICropRenderer render)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerCustomStickRenderer",
+          "sig": "void registerCustomStickRenderer(ICropRenderer render)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerCrop",
+          "sig": "T registerCrop(T crop)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCrop",
+          "sig": "ICrop getCrop(String id, String name)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCrop",
+          "sig": "ICrop getCrop(ResourceLocation location)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getRandomCrop",
+          "sig": "ICrop getRandomCrop(OptionalLong seed)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCrop",
+          "sig": "ICrop getCrop(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getCrops",
+          "sig": "List<ICrop> getCrops()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerDisplayItem",
+          "sig": "void registerDisplayItem(ResourceLocation cropID, ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getDisplayItem",
+          "sig": "ItemStack getDisplayItem(ResourceLocation cropID)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerBaseSeed",
+          "sig": "void registerBaseSeed(Item item, BaseSeed seed)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSeedForStack",
+          "sig": "BaseSeed getSeedForStack(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSeedForCrop",
+          "sig": "ItemStack getSeedForCrop(ICrop crop)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addBiomeHumidityBonus",
+          "sig": "void addBiomeHumidityBonus(TagKey<Biome> type, int bonus)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getHumidityBonus",
+          "sig": "int getHumidityBonus(Holder<Biome> biome)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addBiomeNutrientBonus",
+          "sig": "void addBiomeNutrientBonus(TagKey<Biome> type, int bonus)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getNutrientBonus",
+          "sig": "int getNutrientBonus(Holder<Biome> biome)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "addBiomeWaterQualityBonus",
+          "sig": "void addBiomeWaterQualityBonus(TagKey<Biome> type, int bonus)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getWaterQualityBonus",
+          "sig": "int getWaterQualityBonus(Holder<Biome> biome)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerFarmland",
+          "sig": "void registerFarmland(IFarmland land, Block... blocks)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getFarmland",
+          "sig": "IFarmland getFarmland(Block block)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "registerSubSoil",
+          "sig": "void registerSubSoil(ISubSoil soil, Block... blocks)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSubSoil",
+          "sig": "ISubSoil getSubSoil(Block block)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "WEED",
+          "value": "null",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "SEA_WEED",
+          "value": "null",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "INSTANCE",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "other"
+    },
+    {
+      "fqcn": "ic2.api.events.FoamEvent",
+      "methods": [
+        {
+          "name": "getPos",
+          "sig": "BlockPos getPos()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getState",
+          "sig": "BlockState getState()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getBlockEntity",
+          "sig": "BlockEntity getBlockEntity()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [],
+      "related": [
+        "((), ReferenceType(arguments=None, dimensions=[], name=LevelEvent, sub_type=None))"
+      ],
+      "domain": "events"
+    },
+    {
+      "fqcn": "ic2.api.items.IDrinkableFluid",
+      "methods": [
+        {
+          "name": "drink",
+          "sig": "boolean drink(ItemStack stack, Level world, Player player)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hasSpecialName",
+          "sig": "boolean hasSpecialName()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getSpecialName",
+          "sig": "Component getSpecialName(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "generateSubStates",
+          "sig": "List<ItemStack> generateSubStates(ItemStack base, boolean textures)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTexture",
+          "sig": "ResourceLocation getTexture(ItemStack stack, String baseFolder)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getTextureIndex",
+          "sig": "int getTextureIndex(ItemStack stack)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getID",
+          "sig": "ResourceLocation getID()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "hashCode",
+          "sig": "int hashCode()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "equals",
+          "sig": "boolean equals(Object obj)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "REGISTRY",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [],
+      "domain": "items"
+    },
+    {
+      "fqcn": "ic2.api.reactor.planner.BaseDurabilitySimulatedStack",
+      "methods": [
+        {
+          "name": "save",
+          "sig": "CompoundTag save()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "load",
+          "sig": "void load(CompoundTag data)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "commitState",
+          "sig": "void commitState()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "reset",
+          "sig": "void reset()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "acceptUraniumPulse",
+          "sig": "boolean acceptUraniumPulse(ISimulatedReactor reactor, int x, int y, SimulatedStack source, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canStoreHeat",
+          "sig": "boolean canStoreHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStoredHeat",
+          "sig": "int getStoredHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxStoredHeat",
+          "sig": "int getMaxStoredHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "storeHeat",
+          "sig": "int storeHeat(ISimulatedReactor reactor, int x, int y, int heatChange)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canViewHeat",
+          "sig": "boolean canViewHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExplosionInfluence",
+          "sig": "float getExplosionInfluence(ISimulatedReactor reactor)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getId",
+          "sig": "short getId()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "maxDamage",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "damage",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "id",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [
+        "SimulatedStack"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.reactor.planner.BaseHeatSimulatedStack",
+      "methods": [
+        {
+          "name": "save",
+          "sig": "CompoundTag save()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "load",
+          "sig": "void load(CompoundTag data)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "commitState",
+          "sig": "void commitState()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "reset",
+          "sig": "void reset()",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "acceptUraniumPulse",
+          "sig": "boolean acceptUraniumPulse(ISimulatedReactor reactor, int x, int y, SimulatedStack source, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canStoreHeat",
+          "sig": "boolean canStoreHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getStoredHeat",
+          "sig": "int getStoredHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getMaxStoredHeat",
+          "sig": "int getMaxStoredHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "storeHeat",
+          "sig": "int storeHeat(ISimulatedReactor reactor, int x, int y, int heatChange)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "canViewHeat",
+          "sig": "boolean canViewHeat(ISimulatedReactor reactor, int x, int y)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getExplosionInfluence",
+          "sig": "float getExplosionInfluence(ISimulatedReactor reactor)",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "getId",
+          "sig": "short getId()",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "maxHeat",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "heat",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "id",
+          "value": "unknown",
+          "notes": "DECLARED"
+        },
+        {
+          "name": "heatChanges",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [
+        "SimulatedStack"
+      ],
+      "domain": "reactor"
+    },
+    {
+      "fqcn": "ic2.api.recipes.ingridients.recipes.BaseRecipeOutput",
+      "methods": [
+        {
+          "name": "handleGenerators",
+          "sig": "void handleGenerators(List<IOutputGenerator> generators, List<ItemStack> outputs)",
+          "notes": "DECLARED"
+        }
+      ],
+      "constants": [
+        {
+          "name": "generators",
+          "value": "unknown",
+          "notes": "DECLARED"
+        }
+      ],
+      "related": [
+        "IRecipeOutput"
+      ],
+      "domain": "recipes"
+    }
+  ],
+  "enums": [
+    {
+      "fqcn": "ic2.api.network.tile.PacketRange",
+      "values": [
+        "SHORT_RANGE",
+        "LONG_RANGE",
+        "CHUNK_TRACKED",
+        "ALL_DIM",
+        "ALL_SERVER"
+      ],
+      "domain": "network"
+    },
+    {
+      "fqcn": "ic2.api.recipes.misc.RecipeFlags",
+      "values": [
+        "CONSUME_CONTAINERS",
+        "KEEP_IN_INPUT",
+        "HIDE_RECIPE"
+      ],
+      "domain": "recipes"
+    },
+    {
+      "fqcn": "ic2.api.recipes.misc.RecipeMods",
+      "values": [
+        "ENERGY_USAGE",
+        "RECIPE_TIME"
+      ],
+      "domain": "recipes"
+    }
+  ],
+  "events": [
+    {
+      "fqcn": "ic2.api.events.ArmorSlotEvent",
+      "fields": [],
+      "when": "INFERRED"
+    },
+    {
+      "fqcn": "ic2.api.events.FoamEvent",
+      "fields": [],
+      "when": "INFERRED"
+    },
+    {
+      "fqcn": "ic2.api.events.LaserEvent",
+      "fields": [
+        {
+          "name": "laser",
+          "type": "Entity"
+        },
+        {
+          "name": "source",
+          "type": "LivingEntity"
+        },
+        {
+          "name": "range",
+          "type": "float"
+        },
+        {
+          "name": "power",
+          "type": "float"
+        },
+        {
+          "name": "blockBreaks",
+          "type": "int"
+        },
+        {
+          "name": "explosive",
+          "type": "boolean"
+        },
+        {
+          "name": "smelt",
+          "type": "boolean"
+        }
+      ],
+      "when": "INFERRED"
+    },
+    {
+      "fqcn": "ic2.api.events.RetextureEvent",
+      "fields": [],
+      "when": "INFERRED"
+    },
+    {
+      "fqcn": "ic2.api.events.ScrapBoxEvent",
+      "fields": [],
+      "when": "INFERRED"
+    }
+  ],
+  "capability_hints": [],
+  "reactor_blueprint_hints": [
+    {
+      "class": "ic2.api.reactor.IReactorPlannerComponent",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    },
+    {
+      "class": "ic2.api.reactor.planner.BaseDurabilitySimulatedStack",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    },
+    {
+      "class": "ic2.api.reactor.planner.BaseHeatSimulatedStack",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    },
+    {
+      "class": "ic2.api.reactor.planner.FloatTracker",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    },
+    {
+      "class": "ic2.api.reactor.planner.ISimulatedReactor",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    },
+    {
+      "class": "ic2.api.reactor.planner.SimulatedStack",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    },
+    {
+      "class": "ic2.api.reactor.planner.Tracker",
+      "hint": "INFERRED planner/simulated/tracker role from name"
+    }
+  ]
+}

--- a/inventory_v2/behavior_edges.mmd
+++ b/inventory_v2/behavior_edges.mmd
@@ -1,0 +1,25 @@
+graph TD
+    IEnergyTile -->|registered with| IEnergyNet
+    IEnergySink -->|extends| IEnergyAcceptor
+    IEnergySource -->|extends| IEnergyEmitter
+    IEnergyConductor -->|mediates| IEnergyAcceptor
+    LinkedSink -->|wraps| IEnergyAcceptor
+    LinkedSource -->|wraps| IEnergyEmitter
+    IReactorComponent -->|consumed by| IReactor
+    IReactorPlannerComponent -->|simulates| ISimulatedReactor
+    IReactorChamber -->|adjacent to| IReactor
+    ISteamReactor -->|extends| IReactor
+    SimulatedStack -->|ticks within| ISimulatedReactor
+    IMachine -->|connects to| ITube
+    ITube -->|transports| TransportedItem
+    IProviderTube -->|serves requests from| IRequestTube
+    IWrenchable -->|handled by| IWrenchTool
+    IElectricItem -->|managed by| IElectricItemManager
+    ElectricItem -->|delegates to| IElectricItemManager
+    INetworkFieldProvider -->|synced by| INetworkManager
+    INetworkFieldNotifier -->|notifies| INetworkManager
+    INetworkItemEvent -->|dispatched by| INetworkManager
+    IMachineRecipeList -->|retrieved from| RecipeRegistry
+    IAdvancedCraftingManager -->|owned by| RecipeRegistry
+    FoamEvent -->|emitted during| LevelEvents
+    LaserEvent -->|affects| LevelEvents

--- a/inventory_v2/method_catalog.csv
+++ b/inventory_v2/method_catalog.csv
@@ -1,0 +1,1283 @@
+domain,fqcn,member,kind,signature_or_value,notes
+other,ic2.api.addons.IModule,canLoad,method,boolean canLoad(Dist side),DECLARED
+other,ic2.api.addons.IModule,loadConfigs,method,void loadConfigs(),DECLARED
+other,ic2.api.addons.IModule,preInit,method,void preInit(IEventBus modBus),DECLARED
+other,ic2.api.addons.IModule,postInit,method,void postInit(),DECLARED
+other,ic2.api.blocks.BlockRegistries,registerListener,method,void registerListener(Runnable run),DECLARED
+other,ic2.api.blocks.BlockRegistries,reload,method,void reload(),DECLARED
+other,ic2.api.blocks.BlockRegistries,registerOre,method,"void registerOre(int value, TagKey<Block> tag)",DECLARED
+other,ic2.api.blocks.BlockRegistries,registerOre,method,"void registerOre(int value, Block... blocks)",DECLARED
+other,ic2.api.blocks.BlockRegistries,getBlocksForOreValue,method,Set<Block> getBlocksForOreValue(int value),DECLARED
+other,ic2.api.blocks.BlockRegistries,getOreValue,method,int getOreValue(BlockState state),DECLARED
+other,ic2.api.blocks.BlockRegistries,getOreValue,method,int getOreValue(Block block),DECLARED
+other,ic2.api.blocks.BlockRegistries,getAllValueBlocks,method,List<Block> getAllValueBlocks(),DECLARED
+other,ic2.api.blocks.DyeableMap,addBlock,method,"void addBlock(Block block, DyeColor color)",DECLARED
+other,ic2.api.blocks.DyeableMap,addBlocks,method,"void addBlocks(Map<Block, DyeColor> maps)",DECLARED
+other,ic2.api.blocks.DyeableMap,addReverseBlocks,method,"void addReverseBlocks(Map<DyeColor, Block> maps)",DECLARED
+other,ic2.api.blocks.DyeableMap,getBlock,method,Block getBlock(DyeColor color),DECLARED
+other,ic2.api.blocks.DyeableMap,getBlock,method,"Block getBlock(DyeColor color, Block defaultValue)",DECLARED
+other,ic2.api.blocks.DyeableMap,getColor,method,DyeColor getColor(Block block),DECLARED
+other,ic2.api.blocks.DyeableMap,getBlocks,method,ObjectSet<Block> getBlocks(),DECLARED
+other,ic2.api.blocks.DyeableMap,getBlockArray,method,Block[] getBlockArray(),DECLARED
+other,ic2.api.blocks.DyeableMap,contains,method,boolean contains(Block block),DECLARED
+other,ic2.api.blocks.ExplosionWhitelist,addWhitelist,method,void addWhitelist(Block... blocks),DECLARED
+other,ic2.api.blocks.ExplosionWhitelist,removeWhitelist,method,void removeWhitelist(Block... blocks),DECLARED
+other,ic2.api.blocks.ExplosionWhitelist,isWhitelisted,method,boolean isWhitelisted(Block block),DECLARED
+other,ic2.api.blocks.IAdvancedComparable,getComparatorInputOverride,method,"int getComparatorInputOverride(BlockState state, Level world, BlockPos pos, Direction side)",DECLARED
+other,ic2.api.blocks.IWrenchable,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,doSpecialAction,method,"boolean doSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,hasSpecialAction,method,"AABB hasSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,canRemoveBlock,method,"boolean canRemoveBlock(BlockState state, Level world, BlockPos pos, Player player);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,getDropRate,method,"double getDropRate(BlockState state, Level world, BlockPos pos, Player player);",DECLARED (fallback)
+other,ic2.api.blocks.IWrenchable,getDrops,method,"List<ItemStack> getDrops(BlockState state, Level world, BlockPos pos, Player player);",DECLARED (fallback)
+other,ic2.api.blocks.IPaintable,recolor,method,"boolean recolor(BlockState state, Level world, BlockPos pos, Vec3 exactClick, Direction dir, DyeColor color);",DECLARED (fallback)
+other,ic2.api.blocks.IPaintable,getColor,method,DyeColor getColor(BlockState state);,DECLARED (fallback)
+other,ic2.api.blocks.wrench.BaseWrenchHandler,doSpecialAction,method,"boolean doSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit)",DECLARED
+other,ic2.api.blocks.wrench.BaseWrenchHandler,hasSpecialAction,method,"AABB hasSpecialAction(BlockState state, Level world, BlockPos pos, Direction dir, Player player, Vec3 hit)",DECLARED
+other,ic2.api.blocks.wrench.BaseWrenchHandler,canRemoveBlock,method,"boolean canRemoveBlock(BlockState state, Level world, BlockPos pos, Player player)",DECLARED
+other,ic2.api.blocks.wrench.BaseWrenchHandler,getDropRate,method,"double getDropRate(BlockState state, Level world, BlockPos pos, Player player)",DECLARED
+other,ic2.api.blocks.wrench.BaseWrenchHandler,getDrops,method,"List<ItemStack> getDrops(BlockState state, Level world, BlockPos pos, Player player)",DECLARED
+other,ic2.api.blocks.wrench.ChestWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.ChestWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.DispenserWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.DispenserWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.DispenserWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.DispenserWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.HopperWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.HopperWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.HopperWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.HopperWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.HorizontalWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.HorizontalWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.HorizontalWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.HorizontalWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.InvertedHorizontalWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.InvertedHorizontalWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.InvertedHorizontalWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.InvertedHorizontalWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.ObserverBlockWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.ObserverBlockWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.ObserverBlockWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.ObserverBlockWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.PillarWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.PillarWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.PillarWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.PillarWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.PistonWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.PistonWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.PistonWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.PistonWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.PistonWrenchHandler,canRemoveBlock,method,"boolean canRemoveBlock(BlockState state, Level world, BlockPos pos, Player player)",DECLARED
+other,ic2.api.blocks.wrench.PistonWrenchHandler,getDropRate,method,"double getDropRate(BlockState state, Level world, BlockPos pos, Player player)",DECLARED
+other,ic2.api.blocks.wrench.StairWrenchHandler,INSTANCE,field,IWrenchable INSTANCE,unknown
+other,ic2.api.blocks.wrench.StairWrenchHandler,getFacing,method,"Direction getFacing(BlockState state, Level world, BlockPos pos)",DECLARED
+other,ic2.api.blocks.wrench.StairWrenchHandler,canSetFacing,method,"boolean canSetFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.blocks.wrench.StairWrenchHandler,setFacing,method,"boolean setFacing(BlockState state, Level world, BlockPos pos, Player player, Direction side)",DECLARED
+other,ic2.api.core.APIHelper,getFluidContainers,method,List<ItemStack> getFluidContainers(Fluid fluid),DECLARED
+other,ic2.api.core.APIHelper,createSteam,method,FluidStack createSteam(int amount),DECLARED
+other,ic2.api.core.APIHelper,getTickHelper,method,ITickScheduler getTickHelper(),DECLARED
+other,ic2.api.core.APIHelper,getNetworkManager,method,INetworkManager getNetworkManager(),DECLARED
+other,ic2.api.core.APIHelper,getNetworkManager,method,INetworkManager getNetworkManager(Dist side),DECLARED
+other,ic2.api.core.IC2Classic,TUBE_CAPABILITY,field,Capability<ITube> TUBE_CAPABILITY,get()
+other,ic2.api.core.IC2Classic,NOTIFY_CAPABILITY,field,Capability<INotifiableMachine> NOTIFY_CAPABILITY,get()
+other,ic2.api.core.IC2Classic,ARMOR_CAPABILITY,field,Capability<IArmorCapability> ARMOR_CAPABILITY,get()
+other,ic2.api.core.IC2Classic,getHelper,method,APIHelper getHelper(),DECLARED
+other,ic2.api.core.IC2Classic,setHelper,method,void setHelper(APIHelper helper),DECLARED
+other,ic2.api.crops.BaseSeed,crop,field,ICrop crop,unknown
+other,ic2.api.crops.BaseSeed,stage,field,int stage,unknown
+other,ic2.api.crops.BaseSeed,growth,field,int growth,unknown
+other,ic2.api.crops.BaseSeed,gain,field,int gain,unknown
+other,ic2.api.crops.BaseSeed,resistance,field,int resistance,unknown
+other,ic2.api.crops.BaseSeed,stack_size,field,int stack_size,unknown
+other,ic2.api.crops.CropDifficulty,getWeedChance,method,int getWeedChance(),DECLARED
+other,ic2.api.crops.CropDifficulty,getCropGrowth,method,int getCropGrowth(int value),DECLARED
+other,ic2.api.crops.CropDifficulty,getBreedingDifficulty,method,int getBreedingDifficulty(),DECLARED
+other,ic2.api.crops.CropDifficulty,getCropStats,method,"int[] getCropStats(List<ICropTile> crops, RandomSource rand)",DECLARED
+other,ic2.api.crops.CropProperties,getTier,method,int getTier(),DECLARED
+other,ic2.api.crops.CropProperties,getChemistry,method,int getChemistry(),DECLARED
+other,ic2.api.crops.CropProperties,getConsumable,method,int getConsumable(),DECLARED
+other,ic2.api.crops.CropProperties,getDefensive,method,int getDefensive(),DECLARED
+other,ic2.api.crops.CropProperties,getColorful,method,int getColorful(),DECLARED
+other,ic2.api.crops.CropProperties,getWeed,method,int getWeed(),DECLARED
+other,ic2.api.crops.CropProperties,getAllProperties,method,int[] getAllProperties(),DECLARED
+other,ic2.api.crops.ICrop,UNKNOWN,field,Component UNKNOWN,translatable()
+other,ic2.api.crops.ICrop,EMPTY_DROPS,field,ItemStack[] EMPTY_DROPS,unknown
+other,ic2.api.crops.ICrop,id,method,ResourceLocation id(),DECLARED
+other,ic2.api.crops.ICrop,discoveredBy,method,Component discoveredBy(),DECLARED
+other,ic2.api.crops.ICrop,getName,method,Component getName(),DECLARED
+other,ic2.api.crops.ICrop,getDisplayItem,method,ItemStack getDisplayItem(),DECLARED
+other,ic2.api.crops.ICrop,getProperties,method,CropProperties getProperties(),DECLARED
+other,ic2.api.crops.ICrop,getCropType,method,CropType getCropType(),DECLARED
+other,ic2.api.crops.ICrop,isWaterCleaningCrop,method,boolean isWaterCleaningCrop(ICropTile tile),DECLARED
+other,ic2.api.crops.ICrop,getAttributes,method,String[] getAttributes(),DECLARED
+other,ic2.api.crops.ICrop,getTextures,method,List<ResourceLocation> getTextures(),DECLARED
+other,ic2.api.crops.ICrop,getGrowthSteps,method,int getGrowthSteps(),DECLARED
+other,ic2.api.crops.ICrop,getOptimalHarvestStep,method,int getOptimalHarvestStep(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getGrowthDuration,method,int getGrowthDuration(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getStatInfluence,method,"int getStatInfluence(ICropTile cropTile, int humidity, int nutrients, int air)",DECLARED
+other,ic2.api.crops.ICrop,canGrow,method,boolean canGrow(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,canBeHarvested,method,boolean canBeHarvested(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getAfterHarvestStage,method,int getAfterHarvestStage(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getDropChance,method,double getDropChance(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getDrops,method,ItemStack[] getDrops(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getSeedDropChance,method,float getSeedDropChance(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getSeeds,method,ItemStack getSeeds(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,canBreed,method,boolean canBreed(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,isWeed,method,boolean isWeed(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,onRightClick,method,"boolean onRightClick(ICropTile cropTile, Player player, InteractionHand hand)",DECLARED
+other,ic2.api.crops.ICrop,onLeftClick,method,"boolean onLeftClick(ICropTile cropTile, Player player)",DECLARED
+other,ic2.api.crops.ICrop,onTick,method,void onTick(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,onBlockUpdate,method,void onBlockUpdate(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,onEntityCollision,method,"void onEntityCollision(ICropTile cropTile, Entity entity)",DECLARED
+other,ic2.api.crops.ICrop,onCropPlaceFailed,method,"void onCropPlaceFailed(BaseSeed seed, ICropTile cropTile, Player player)",DECLARED
+other,ic2.api.crops.ICrop,hasCustomCropPlaceFailedMessage,method,boolean hasCustomCropPlaceFailedMessage(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getCustomCropPlaceFailedMessage,method,Component getCustomCropPlaceFailedMessage(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,canEmitRedstone,method,boolean canEmitRedstone(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getRedstoneLevel,method,int getRedstoneLevel(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,getEmittedLight,method,int getEmittedLight(ICropTile cropTile),DECLARED
+other,ic2.api.crops.ICrop,desc,method,String desc(int i),DECLARED
+other,ic2.api.crops.ICrop,getGrowth,method,int getGrowth(int combo),DECLARED
+other,ic2.api.crops.ICrop,getGain,method,int getGain(int combo),DECLARED
+other,ic2.api.crops.ICrop,getResistance,method,int getResistance(int combo),DECLARED
+other,ic2.api.crops.ICrop,combineStats,method,"short combineStats(int growth, int gain, int resistance)",DECLARED
+other,ic2.api.crops.ICropModifier,canChangeSeedMode,method,boolean canChangeSeedMode(ItemStack input),DECLARED
+other,ic2.api.crops.ICropModifier,canToggleSeedMode,method,boolean canToggleSeedMode(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropRegistry,WEED,field,ICrop WEED,null
+other,ic2.api.crops.ICropRegistry,SEA_WEED,field,ICrop SEA_WEED,null
+other,ic2.api.crops.ICropRegistry,INSTANCE,field,ICropRegistry INSTANCE,unknown
+other,ic2.api.crops.ICropRegistry,registerCustomCropRenderer,method,"void registerCustomCropRenderer(ResourceLocation location, ICropRenderer render)",DECLARED
+other,ic2.api.crops.ICropRegistry,registerCustomStickRenderer,method,void registerCustomStickRenderer(ICropRenderer render),DECLARED
+other,ic2.api.crops.ICropRegistry,registerCrop,method,T registerCrop(T crop),DECLARED
+other,ic2.api.crops.ICropRegistry,getCrop,method,"ICrop getCrop(String id, String name)",DECLARED
+other,ic2.api.crops.ICropRegistry,getCrop,method,ICrop getCrop(ResourceLocation location),DECLARED
+other,ic2.api.crops.ICropRegistry,getRandomCrop,method,ICrop getRandomCrop(OptionalLong seed),DECLARED
+other,ic2.api.crops.ICropRegistry,getCrop,method,ICrop getCrop(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropRegistry,getCrops,method,List<ICrop> getCrops(),DECLARED
+other,ic2.api.crops.ICropRegistry,registerDisplayItem,method,"void registerDisplayItem(ResourceLocation cropID, ItemStack stack)",DECLARED
+other,ic2.api.crops.ICropRegistry,getDisplayItem,method,ItemStack getDisplayItem(ResourceLocation cropID),DECLARED
+other,ic2.api.crops.ICropRegistry,registerBaseSeed,method,"void registerBaseSeed(Item item, BaseSeed seed)",DECLARED
+other,ic2.api.crops.ICropRegistry,getSeedForStack,method,BaseSeed getSeedForStack(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropRegistry,getSeedForCrop,method,ItemStack getSeedForCrop(ICrop crop),DECLARED
+other,ic2.api.crops.ICropRegistry,addBiomeHumidityBonus,method,"void addBiomeHumidityBonus(TagKey<Biome> type, int bonus)",DECLARED
+other,ic2.api.crops.ICropRegistry,getHumidityBonus,method,int getHumidityBonus(Holder<Biome> biome),DECLARED
+other,ic2.api.crops.ICropRegistry,addBiomeNutrientBonus,method,"void addBiomeNutrientBonus(TagKey<Biome> type, int bonus)",DECLARED
+other,ic2.api.crops.ICropRegistry,getNutrientBonus,method,int getNutrientBonus(Holder<Biome> biome),DECLARED
+other,ic2.api.crops.ICropRegistry,addBiomeWaterQualityBonus,method,"void addBiomeWaterQualityBonus(TagKey<Biome> type, int bonus)",DECLARED
+other,ic2.api.crops.ICropRegistry,getWaterQualityBonus,method,int getWaterQualityBonus(Holder<Biome> biome),DECLARED
+other,ic2.api.crops.ICropRegistry,registerFarmland,method,"void registerFarmland(IFarmland land, Block... blocks)",DECLARED
+other,ic2.api.crops.ICropRegistry,getFarmland,method,IFarmland getFarmland(Block block),DECLARED
+other,ic2.api.crops.ICropRegistry,registerSubSoil,method,"void registerSubSoil(ISubSoil soil, Block... blocks)",DECLARED
+other,ic2.api.crops.ICropRegistry,getSubSoil,method,ISubSoil getSubSoil(Block block),DECLARED
+other,ic2.api.crops.ICropRenderer,createQuadsForStage,method,"List<BakedQuad> createQuadsForStage(int stage, boolean fancy, FaceBakery baker)",DECLARED
+other,ic2.api.crops.ICropSeed,SCAN_COST,field,int[] SCAN_COST,unknown
+other,ic2.api.crops.ICropSeed,TIERS,field,String[] TIERS,unknown
+other,ic2.api.crops.ICropSeed,getCrop,method,ICrop getCrop(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropSeed,getScanLevel,method,int getScanLevel(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropSeed,setScanLevel,method,"void setScanLevel(ItemStack stack, int level)",DECLARED
+other,ic2.api.crops.ICropSeed,increaseScanLevel,method,void increaseScanLevel(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropSeed,getGrowth,method,int getGrowth(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropSeed,setGrowth,method,"void setGrowth(ItemStack stack, int growth)",DECLARED
+other,ic2.api.crops.ICropSeed,getGain,method,int getGain(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropSeed,setGain,method,"void setGain(ItemStack stack, int gain)",DECLARED
+other,ic2.api.crops.ICropSeed,getResistance,method,int getResistance(ItemStack stack),DECLARED
+other,ic2.api.crops.ICropSeed,setResistance,method,"void setResistance(ItemStack stack, int resistance)",DECLARED
+other,ic2.api.crops.ICropTile,getFarmland,method,IFarmland getFarmland(),DECLARED
+other,ic2.api.crops.ICropTile,isWaterLogged,method,boolean isWaterLogged(),DECLARED
+other,ic2.api.crops.ICropTile,setWaterlogged,method,void setWaterlogged(boolean water),DECLARED
+other,ic2.api.crops.ICropTile,getCrop,method,ICrop getCrop(),DECLARED
+other,ic2.api.crops.ICropTile,setCrop,method,void setCrop(ICrop crop),DECLARED
+other,ic2.api.crops.ICropTile,getGrowthStage,method,int getGrowthStage(),DECLARED
+other,ic2.api.crops.ICropTile,setGrowthStage,method,void setGrowthStage(int stage),DECLARED
+other,ic2.api.crops.ICropTile,getGrowthPoints,method,int getGrowthPoints(),DECLARED
+other,ic2.api.crops.ICropTile,setGrowthPoints,method,void setGrowthPoints(int points),DECLARED
+other,ic2.api.crops.ICropTile,getScanLevel,method,int getScanLevel(),DECLARED
+other,ic2.api.crops.ICropTile,setScanLevel,method,void setScanLevel(int level),DECLARED
+other,ic2.api.crops.ICropTile,isCrossBreeding,method,boolean isCrossBreeding(),DECLARED
+other,ic2.api.crops.ICropTile,setCrossBreeding,method,void setCrossBreeding(boolean breed),DECLARED
+other,ic2.api.crops.ICropTile,getGainStat,method,int getGainStat(),DECLARED
+other,ic2.api.crops.ICropTile,setGainStat,method,void setGainStat(int level),DECLARED
+other,ic2.api.crops.ICropTile,getGrowthStat,method,int getGrowthStat(),DECLARED
+other,ic2.api.crops.ICropTile,setGrowthStat,method,void setGrowthStat(int level),DECLARED
+other,ic2.api.crops.ICropTile,getResistanceStat,method,int getResistanceStat(),DECLARED
+other,ic2.api.crops.ICropTile,setResistanceStat,method,void setResistanceStat(int level),DECLARED
+other,ic2.api.crops.ICropTile,canBreed,method,boolean canBreed(),DECLARED
+other,ic2.api.crops.ICropTile,requestStateUpdate,method,void requestStateUpdate(),DECLARED
+other,ic2.api.crops.ICropTile,onCustomDataChanged,method,void onCustomDataChanged(),DECLARED
+other,ic2.api.crops.ICropTile,calculateGrowthSpeed,method,int calculateGrowthSpeed(),DECLARED
+other,ic2.api.crops.ICropTile,performManualHarvest,method,boolean performManualHarvest(),DECLARED
+other,ic2.api.crops.ICropTile,performHarvest,method,List<ItemStack> performHarvest(boolean manual),DECLARED
+other,ic2.api.crops.ICropTile,pickCrop,method,boolean pickCrop(),DECLARED
+other,ic2.api.crops.ICropTile,removeCrop,method,void removeCrop(),DECLARED
+other,ic2.api.crops.ICropTile,isBlockBelow,method,boolean isBlockBelow(BlockState state),DECLARED
+other,ic2.api.crops.ICropTile,isBlockBelow,method,boolean isBlockBelow(Block block),DECLARED
+other,ic2.api.crops.ICropTile,isBlockBelow,method,boolean isBlockBelow(TagKey<Block> tag),DECLARED
+other,ic2.api.crops.ICropTile,getBlocksBelow,method,Set<Block> getBlocksBelow(),DECLARED
+other,ic2.api.crops.ICropTile,getCustomData,method,CompoundTag getCustomData(),DECLARED
+other,ic2.api.crops.ICropTile,getLightLevel,method,int getLightLevel(),DECLARED
+other,ic2.api.crops.ICropTile,getEnvironmentQuality,method,int getEnvironmentQuality(),DECLARED
+other,ic2.api.crops.ICropTile,getNutrients,method,int getNutrients(),DECLARED
+other,ic2.api.crops.ICropTile,getHumidity,method,int getHumidity(),DECLARED
+other,ic2.api.crops.ICropTile,getWaterStorage,method,int getWaterStorage(),DECLARED
+other,ic2.api.crops.ICropTile,setWaterStorage,method,void setWaterStorage(int water),DECLARED
+other,ic2.api.crops.ICropTile,getFertilizerStorage,method,int getFertilizerStorage(),DECLARED
+other,ic2.api.crops.ICropTile,setFertilizerStorage,method,void setFertilizerStorage(int fertilizer),DECLARED
+other,ic2.api.crops.ICropTile,getWeedExStorage,method,int getWeedExStorage(),DECLARED
+other,ic2.api.crops.ICropTile,setWeedExStorage,method,void setWeedExStorage(int weedEx),DECLARED
+other,ic2.api.crops.ICropTile,createSeeds,method,"ItemStack createSeeds(ICrop crop, int growthStat, int gainStat, int resistanceStat, int scanLevel)",DECLARED
+other,ic2.api.crops.IFarmland,getHumidity,method,"int getHumidity(Level world, BlockPos pos)",DECLARED
+other,ic2.api.crops.IFarmland,getHumidity,method,int getHumidity(BlockState state),DECLARED
+other,ic2.api.crops.IFarmland,getNutrients,method,"int getNutrients(Level world, BlockPos pos)",DECLARED
+other,ic2.api.crops.IFarmland,getNutrients,method,int getNutrients(BlockState state),DECLARED
+other,ic2.api.crops.IFarmland,isSpecial,method,boolean isSpecial(),DECLARED
+other,ic2.api.crops.IFarmland,getSpecialState,method,BlockState getSpecialState(Block block),DECLARED
+other,ic2.api.crops.ISeedCrop,isDroppingSeeds,method,boolean isDroppingSeeds(ICropTile tile),DECLARED
+other,ic2.api.crops.ISeedCrop,getSeedDrops,method,ItemStack[] getSeedDrops(ICropTile tile),DECLARED
+other,ic2.api.crops.ISubSoil,getHumidity,method,"int getHumidity(Level world, BlockPos pos)",DECLARED
+other,ic2.api.crops.ISubSoil,getHumidity,method,int getHumidity(BlockState state),DECLARED
+other,ic2.api.crops.ISubSoil,getNutrients,method,"int getNutrients(Level world, BlockPos pos)",DECLARED
+other,ic2.api.crops.ISubSoil,getNutrients,method,int getNutrients(BlockState state),DECLARED
+other,ic2.api.crops.ISubSoil,isSpecial,method,boolean isSpecial(),DECLARED
+other,ic2.api.crops.ISubSoil,getSpecialState,method,BlockState getSpecialState(Block block),DECLARED
+energy,ic2.api.energy.EnergyNet,INSTANCE,field,IEnergyNet INSTANCE,unknown
+energy,ic2.api.energy.IEnergyNet,getTile,method,"IEnergyTile getTile(Level world, BlockPos pos)",DECLARED
+energy,ic2.api.energy.IEnergyNet,getSubTile,method,"IEnergyTile getSubTile(Level world, BlockPos pos)",DECLARED
+energy,ic2.api.energy.IEnergyNet,getTiles,method,"GridTile getTiles(Level world, BlockPos pos)",DECLARED
+energy,ic2.api.energy.IEnergyNet,addTile,method,void addTile(IEnergyTile tile),DECLARED
+energy,ic2.api.energy.IEnergyNet,removeTile,method,void removeTile(IEnergyTile tile),DECLARED
+energy,ic2.api.energy.IEnergyNet,updateTile,method,void updateTile(IEnergyTile tile),DECLARED
+energy,ic2.api.energy.IEnergyNet,getPowerFromTier,method,int getPowerFromTier(int tier),DECLARED
+energy,ic2.api.energy.IEnergyNet,getTierFromPower,method,int getTierFromPower(int power),DECLARED
+energy,ic2.api.energy.IEnergyNet,getDisplayTier,method,String getDisplayTier(int tier),DECLARED
+energy,ic2.api.energy.IEnergyNet,getStats,method,TransferStats getStats(IEnergyTile tile),DECLARED
+energy,ic2.api.energy.IEnergyNet,getPacketStats,method,List<PacketStats> getPacketStats(IEnergyTile tile),DECLARED
+energy,ic2.api.energy.PacketStats,getTile,method,IEnergyTile getTile(),DECLARED
+energy,ic2.api.energy.PacketStats,getPackets,method,long getPackets(),DECLARED
+energy,ic2.api.energy.PacketStats,getPower,method,long getPower(),DECLARED
+energy,ic2.api.energy.PacketStats,isAccepting,method,boolean isAccepting(),DECLARED
+energy,ic2.api.energy.TransferStats,getEnergyIn,method,long getEnergyIn(),DECLARED
+energy,ic2.api.energy.TransferStats,getEnergyOut,method,long getEnergyOut(),DECLARED
+energy,ic2.api.energy.TransferStats,getEnergyLossIn,method,long getEnergyLossIn(),DECLARED
+energy,ic2.api.energy.TransferStats,getEnergyLossOut,method,long getEnergyLossOut(),DECLARED
+energy,ic2.api.energy.TransferStats,toString,method,String toString(),DECLARED
+energy,ic2.api.energy.impl.LinkedSink,getWorldObj,method,Level getWorldObj(),DECLARED
+energy,ic2.api.energy.impl.LinkedSink,getPosition,method,BlockPos getPosition(),DECLARED
+energy,ic2.api.energy.impl.LinkedSink,canAcceptEnergy,method,"boolean canAcceptEnergy(IEnergyEmitter emitter, Direction side)",DECLARED
+energy,ic2.api.energy.impl.LinkedSource,getWorldObj,method,Level getWorldObj(),DECLARED
+energy,ic2.api.energy.impl.LinkedSource,getPosition,method,BlockPos getPosition(),DECLARED
+energy,ic2.api.energy.impl.LinkedSource,canEmitEnergy,method,"boolean canEmitEnergy(IEnergyAcceptor acceptor, Direction side)",DECLARED
+energy,ic2.api.energy.tile.IEnergyAcceptor,canAcceptEnergy,method,"boolean canAcceptEnergy(IEnergyEmitter emitter, Direction side)",DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,isWaterlogged,method,boolean isWaterlogged(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,isLavaLogged,method,boolean isLavaLogged(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,getConductionLoss,method,double getConductionLoss(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,getInsulationEnergyAbsorption,method,int getInsulationEnergyAbsorption(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,getInsulationBreakdownEnergy,method,int getInsulationBreakdownEnergy(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,getConductorBreakdownEnergy,method,int getConductorBreakdownEnergy(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,removeInsulation,method,void removeInsulation(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductor,removeConductor,method,void removeConductor(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductorColored,getColor,method,DyeColor getColor(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductorModifiable,tryAddInsulation,method,boolean tryAddInsulation(),DECLARED
+energy,ic2.api.energy.tile.IEnergyConductorModifiable,tryRemoveInsulation,method,boolean tryRemoveInsulation(),DECLARED
+energy,ic2.api.energy.tile.IEnergyEmitter,canEmitEnergy,method,"boolean canEmitEnergy(IEnergyAcceptor acceptor, Direction side)",DECLARED
+energy,ic2.api.energy.tile.IEnergySink,getSinkTier,method,int getSinkTier(),DECLARED
+energy,ic2.api.energy.tile.IEnergySink,getRequestedEnergy,method,int getRequestedEnergy(),DECLARED
+energy,ic2.api.energy.tile.IEnergySink,acceptEnergy,method,"int acceptEnergy(Direction side, int amount, int voltage)",DECLARED
+energy,ic2.api.energy.tile.IEnergySource,getSourceTier,method,int getSourceTier(),DECLARED
+energy,ic2.api.energy.tile.IEnergySource,getMaxEnergyOutput,method,int getMaxEnergyOutput(),DECLARED
+energy,ic2.api.energy.tile.IEnergySource,getProvidedEnergy,method,int getProvidedEnergy(),DECLARED
+energy,ic2.api.energy.tile.IEnergySource,consumeEnergy,method,void consumeEnergy(int consumed),DECLARED
+energy,ic2.api.energy.tile.IEnergySource,onPacketFailed,method,void onPacketFailed(),DECLARED
+energy,ic2.api.energy.tile.IEnergySource,getSourceType,method,SourceType getSourceType(),DECLARED
+energy,ic2.api.energy.tile.IMultiEnergySource,hasMultiplePackets,method,boolean hasMultiplePackets(),DECLARED
+energy,ic2.api.energy.tile.IMultiEnergySource,getPacketCount,method,int getPacketCount(),DECLARED
+energy,ic2.api.energy.tile.IMultiEnergyTile,getTiles,method,List<IEnergyTile> getTiles(),DECLARED
+events,ic2.api.events.ArmorSlotEvent,getItem,method,Item getItem(),DECLARED
+events,ic2.api.events.ArmorSlotEvent,getId,method,String getId(),DECLARED
+events,ic2.api.events.ArmorSlotEvent,getEquipmentSlot,method,EquipmentSlot getEquipmentSlot(),DECLARED
+events,ic2.api.events.ArmorSlotEvent,getSlots,method,Object2IntMap<ModuleType> getSlots(),DECLARED
+events,ic2.api.events.ArmorSlotEvent,addSlots,method,"void addSlots(ModuleType type, int amount)",DECLARED
+events,ic2.api.events.FoamEvent,getPos,method,BlockPos getPos(),DECLARED
+events,ic2.api.events.FoamEvent,getState,method,BlockState getState(),DECLARED
+events,ic2.api.events.FoamEvent,getBlockEntity,method,BlockEntity getBlockEntity(),DECLARED
+events,ic2.api.events.LaserEvent,laser,field,Entity laser,unknown
+events,ic2.api.events.LaserEvent,source,field,LivingEntity source,unknown
+events,ic2.api.events.LaserEvent,range,field,float range,0F
+events,ic2.api.events.LaserEvent,power,field,float power,0F
+events,ic2.api.events.LaserEvent,blockBreaks,field,int blockBreaks,0
+events,ic2.api.events.LaserEvent,explosive,field,boolean explosive,false
+events,ic2.api.events.LaserEvent,smelt,field,boolean smelt,false
+events,ic2.api.events.RetextureEvent,getPos,method,BlockPos getPos(),DECLARED
+events,ic2.api.events.RetextureEvent,getSide,method,Direction getSide(),DECLARED
+events,ic2.api.events.RetextureEvent,getBlockState,method,BlockState getBlockState(),DECLARED
+events,ic2.api.events.RetextureEvent,getBlockEntity,method,BlockEntity getBlockEntity(),DECLARED
+events,ic2.api.events.RetextureEvent,getApplyingPlayer,method,Player getApplyingPlayer(),DECLARED
+events,ic2.api.events.RetextureEvent,getContainer,method,TextureContainer getContainer(),DECLARED
+events,ic2.api.events.RetextureEvent,isApplied,method,boolean isApplied(),DECLARED
+events,ic2.api.events.RetextureEvent,setApplied,method,void setApplied(boolean apply),DECLARED
+events,ic2.api.events.ScrapBoxEvent,getDrops,method,List<ItemStack> getDrops(),DECLARED
+events,ic2.api.events.ScrapBoxEvent,getScrapBox,method,ItemStack getScrapBox(),DECLARED
+items,ic2.api.items.IAutoEatable,canAutoEat,method,boolean canAutoEat(ItemStack stack),DECLARED
+items,ic2.api.items.IAutoEatable,getFoodValue,method,int getFoodValue(ItemStack stack),DECLARED
+items,ic2.api.items.IAutoEatable,onEaten,method,"ItemStack onEaten(ItemStack stack, Level level, Player player)",DECLARED
+items,ic2.api.items.IBoxableItem,canStoreIntoBox,method,boolean canStoreIntoBox(ItemStack stack),DECLARED
+items,ic2.api.items.ICoinItem,getMoneyValue,method,int getMoneyValue(ItemStack stack),DECLARED
+items,ic2.api.items.ICutterItem,cutInsulation,method,"void cutInsulation(Player player, ItemStack stack, Level world, BlockPos pos)",DECLARED
+items,ic2.api.items.IDisplayProvider,provideInfo,method,"void provideInfo(ItemStack stack, Consumer<IDisplayInfo> infos)",DECLARED
+items,ic2.api.items.IDrinkContainer,getCapacity,method,int getCapacity(),DECLARED
+items,ic2.api.items.IDrinkContainer,getContent,method,IDrinkableFluid getContent(ItemStack stack),DECLARED
+items,ic2.api.items.IDrinkContainer,hasContent,method,boolean hasContent(ItemStack stack),DECLARED
+items,ic2.api.items.IDrinkContainer,fillWith,method,"ItemStack fillWith(IDrinkableFluid fluid, int amount)",DECLARED
+items,ic2.api.items.IDrinkContainer,getEmptyContainer,method,ItemStack getEmptyContainer(),DECLARED
+items,ic2.api.items.IDrinkableFluid,REGISTRY,field,"Map<ResourceLocation, IDrinkableFluid> REGISTRY",unknown
+items,ic2.api.items.IDrinkableFluid,drink,method,"boolean drink(ItemStack stack, Level world, Player player)",DECLARED
+items,ic2.api.items.IDrinkableFluid,hasSpecialName,method,boolean hasSpecialName(),DECLARED
+items,ic2.api.items.IDrinkableFluid,getSpecialName,method,Component getSpecialName(ItemStack stack),DECLARED
+items,ic2.api.items.IDrinkableFluid,generateSubStates,method,"List<ItemStack> generateSubStates(ItemStack base, boolean textures)",DECLARED
+items,ic2.api.items.IDrinkableFluid,getTexture,method,"ResourceLocation getTexture(ItemStack stack, String baseFolder)",DECLARED
+items,ic2.api.items.IDrinkableFluid,getTextureIndex,method,int getTextureIndex(ItemStack stack),DECLARED
+items,ic2.api.items.IDrinkableFluid,getID,method,ResourceLocation getID(),DECLARED
+items,ic2.api.items.IDrinkableFluid,hashCode,method,int hashCode(),DECLARED
+items,ic2.api.items.IDrinkableFluid,equals,method,boolean equals(Object obj),DECLARED
+items,ic2.api.items.IFuelableItem,fill,method,"ItemStack fill(ItemStack stack, int amount)",DECLARED
+items,ic2.api.items.IFuelableItem,canFuel,method,boolean canFuel(ItemStack stack),DECLARED
+items,ic2.api.items.IFuelableItem,hasFuel,method,boolean hasFuel(ItemStack stack),DECLARED
+items,ic2.api.items.IFuelableItem,getFuel,method,"int getFuel(ItemStack stack, int requested, boolean doDrain)",DECLARED
+items,ic2.api.items.IRepairable,repairDamage,method,"boolean repairDamage(ItemStack stack, int amount)",DECLARED
+items,ic2.api.items.ITagBlock,matches,method,"boolean matches(ItemStack self, Block block)",DECLARED
+items,ic2.api.items.ITagBlock,getBlocks,method,List<Block> getBlocks(ItemStack self),DECLARED
+items,ic2.api.items.ITagItem,matches,method,"boolean matches(ItemStack self, ItemStack toCompare)",DECLARED
+items,ic2.api.items.ITerraformerBP,canInsert,method,"boolean canInsert(ItemStack stack, Player player, Level world, BlockPos pos)",DECLARED
+items,ic2.api.items.ITerraformerBP,onInsert,method,"void onInsert(ItemStack stack, Player player, Level world, BlockPos pos)",DECLARED
+items,ic2.api.items.ITerraformerBP,isRandomized,method,boolean isRandomized(ItemStack stack),DECLARED
+items,ic2.api.items.ITerraformerBP,getEnergyUsage,method,int getEnergyUsage(ItemStack stack),DECLARED
+items,ic2.api.items.ITerraformerBP,getRadius,method,int getRadius(ItemStack stack),DECLARED
+items,ic2.api.items.ITerraformerBP,terraform,method,"boolean terraform(ItemStack stack, Level world, BlockPos position, ITerraformer terraformer)",DECLARED
+items,ic2.api.items.IUpgradeItem,getType,method,UpgradeType getType(ItemStack stack),DECLARED
+items,ic2.api.items.IUpgradeItem,getFunctions,method,EnumSet<Functions> getFunctions(ItemStack stack),DECLARED
+items,ic2.api.items.IUpgradeItem,onInstall,method,"void onInstall(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getProcessingSpeedMultiplier,method,"double getProcessingSpeedMultiplier(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getExtraProcessingSpeed,method,"int getExtraProcessingSpeed(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getProcessingTimeMultiplier,method,"double getProcessingTimeMultiplier(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getExtraProcessingTime,method,"int getExtraProcessingTime(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getEnergyDemandMultiplier,method,"double getEnergyDemandMultiplier(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getExtraEnergyDemand,method,"int getExtraEnergyDemand(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getEnergyStorageMultiplier,method,"double getEnergyStorageMultiplier(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getExtraEnergyStorage,method,"int getExtraEnergyStorage(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getExtraTier,method,"int getExtraTier(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,getSoundMultiplier,method,"float getSoundMultiplier(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,useRedstoneInvertion,method,"boolean useRedstoneInvertion(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,onTick,method,"void onTick(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IUpgradeItem,onMachineFinishedRecipePre,method,"void onMachineFinishedRecipePre(ItemStack stack, IMachine machine, IRecipeOutput output, CompoundTag recipeFlags)",DECLARED
+items,ic2.api.items.IUpgradeItem,onMachineFinishedRecipePost,method,"void onMachineFinishedRecipePost(ItemStack stack, IMachine machine, RecipeEntry entry, List<IStackOutput> drops)",DECLARED
+items,ic2.api.items.IUpgradeItem,onMachineProcessed,method,"void onMachineProcessed(ItemStack stack, IMachine machine)",DECLARED
+items,ic2.api.items.IWindmillBlade,getRadius,method,int getRadius(ItemStack stack),DECLARED
+items,ic2.api.items.IWindmillBlade,getEffectiveness,method,float getEffectiveness(ItemStack stack),DECLARED
+items,ic2.api.items.IWindmillBlade,getTexture,method,ResourceLocation getTexture(ItemStack stack),DECLARED
+items,ic2.api.items.ItemRegistries,registerMetalArmor,method,"void registerMetalArmor(IMetalArmor armor, Item... items)",DECLARED
+items,ic2.api.items.ItemRegistries,isMetalArmor,method,"boolean isMetalArmor(Player player, EquipmentSlot slot)",DECLARED
+items,ic2.api.items.ItemRegistries,registerBoxableItems,method,"void registerBoxableItems(IBoxableItem box, Item... items)",DECLARED
+items,ic2.api.items.ItemRegistries,isBoxable,method,boolean isBoxable(ItemStack stack),DECLARED
+items,ic2.api.items.ItemRegistries,registerCoin,method,void registerCoin(Item item),DECLARED
+items,ic2.api.items.ItemRegistries,generateCoins,method,"NonNullList<ItemStack> generateCoins(int coinValue, NonNullList<ItemStack> result, boolean limit)",DECLARED
+items,ic2.api.items.ItemRegistries,registerBlockableDamageSource,method,"void registerBlockableDamageSource(ShieldItem shield, DamageSource source)",DECLARED
+items,ic2.api.items.ItemRegistries,registerBlockableDamageSource,method,void registerBlockableDamageSource(DamageSource source),DECLARED
+items,ic2.api.items.ItemRegistries,isDamageSourceBlockable,method,"boolean isDamageSourceBlockable(ShieldItem shield, DamageSource source)",DECLARED
+items,ic2.api.items.armor.IArmorHud,isHudEnabled,method,boolean isHudEnabled(ItemStack stack),DECLARED
+items,ic2.api.items.armor.IArmorModule,getType,method,ModuleType getType(ItemStack stack),DECLARED
+items,ic2.api.items.armor.IArmorModule,canInstallInArmor,method,"boolean canInstallInArmor(ItemStack stack, ItemStack armor, EquipmentSlot type)",DECLARED
+items,ic2.api.items.armor.IArmorModule,onInstall,method,"void onInstall(ItemStack stack, ItemStack armor, IArmorModuleHolder holder)",DECLARED
+items,ic2.api.items.armor.IArmorModule,onUninstall,method,"void onUninstall(ItemStack stack, ItemStack armor, IArmorModuleHolder holder)",DECLARED
+items,ic2.api.items.armor.IArmorModule,transferToArmor,method,"void transferToArmor(ItemStack stack, ItemStack oldArmor, ItemStack newArmor)",DECLARED
+items,ic2.api.items.armor.IArmorModule,onTick,method,"void onTick(ItemStack stack, ItemStack armor, Level world, Player player)",DECLARED
+items,ic2.api.items.armor.IArmorModule,onEquipped,method,"void onEquipped(ItemStack stack, ItemStack armor, Player entity)",DECLARED
+items,ic2.api.items.armor.IArmorModule,onUnequipped,method,"void onUnequipped(ItemStack stack, ItemStack armor, Player entity)",DECLARED
+items,ic2.api.items.armor.IArmorModule,provideCapabilities,method,"void provideCapabilities(ItemStack stack, ItemStack armor)",DECLARED
+items,ic2.api.items.armor.IArmorModule,handlePacket,method,"boolean handlePacket(Player player, ItemStack module, ItemStack armor, String id, INetworkDataBuffer buffer, Dist targetSide)",DECLARED
+items,ic2.api.items.armor.IArmorModule,handleToolTip,method,"void handleToolTip(ItemStack stack, Consumer<MutableComponent> results)",DECLARED
+items,ic2.api.items.armor.ICustomArmor,getProperties,method,"AbsorptionProperties getProperties(LivingEntity entity, ItemStack armor, DamageSource source, double damage, EquipmentSlot slot)",DECLARED
+items,ic2.api.items.armor.ICustomArmor,damageArmor,method,"void damageArmor(LivingEntity player, ItemStack stack, DamageSource source, int damage, EquipmentSlot slot, DamageType type)",DECLARED
+items,ic2.api.items.armor.ICustomArmor,canBlockDamageSource,method,"boolean canBlockDamageSource(LivingEntity player, ItemStack stack, DamageSource source, EquipmentSlot slot)",DECLARED
+items,ic2.api.items.armor.IEnergyShieldArmor,addsShieldEffect,method,"boolean addsShieldEffect(EquipmentSlot type, LivingEntity entity, ItemStack stack)",DECLARED
+items,ic2.api.items.armor.IEnergyShieldArmor,isEffectAlwaysOn,method,"boolean isEffectAlwaysOn(EquipmentSlot type, LivingEntity entity, ItemStack stack)",DECLARED
+items,ic2.api.items.armor.IEnergyShieldArmor,addsEnergyShieldEffect,method,boolean addsEnergyShieldEffect(LivingEntity living),DECLARED
+items,ic2.api.items.armor.IEnergyShieldArmor,shouldAlwaysShowEffect,method,boolean shouldAlwaysShowEffect(LivingEntity living),DECLARED
+items,ic2.api.items.armor.IFoamSupplier,canProvideFoam,method,"boolean canProvideFoam(Player player, ItemStack stack, InventoryType inv, int amount)",DECLARED
+items,ic2.api.items.armor.IFoamSupplier,useFoam,method,"void useFoam(Player player, ItemStack stack, int amount)",DECLARED
+items,ic2.api.items.armor.IFoamSupplier,getFreeFoamSpace,method,int getFreeFoamSpace(ItemStack stack),DECLARED
+items,ic2.api.items.armor.IFoamSupplier,fillFoam,method,"void fillFoam(ItemStack stack, int amount)",DECLARED
+items,ic2.api.items.armor.IMetalArmor,isMetalArmor,method,"boolean isMetalArmor(ItemStack stack, Player player, EquipmentSlot targetSlot)",DECLARED
+items,ic2.api.items.electric.ElectricItem,MANAGER,field,IElectricItemManager MANAGER,unknown
+items,ic2.api.items.electric.ElectricItem,DIRECT_MANAGER,field,IElectricItemManager DIRECT_MANAGER,unknown
+items,ic2.api.items.electric.ElectricItem,registerBackupManager,method,"void registerBackupManager(IElectricItemManager manager, ItemLike... items)",DECLARED
+items,ic2.api.items.electric.ElectricItem,setCurioSupport,method,"void setCurioSupport(Function<Player, IItemHandler> curio)",DECLARED
+items,ic2.api.items.electric.ElectricItem,getBackupManager,method,IElectricItemManager getBackupManager(Item item),DECLARED
+items,ic2.api.items.electric.ElectricItem,chargeArmor,method,"int chargeArmor(Player player, int provided)",DECLARED
+items,ic2.api.items.electric.ElectricItem,chargeArmor,method,"int chargeArmor(Player player, int provided, boolean whitelist, EquipmentSlot... slots)",DECLARED
+items,ic2.api.items.electric.ElectricItem,chargeArmor,method,"int chargeArmor(Player player, int provided, boolean whitelist, boolean allowCurio, EquipmentSlot... slots)",DECLARED
+items,ic2.api.items.electric.ElectricItem,chargeCurio,method,"int chargeCurio(IItemHandler handler, int energyProvided)",DECLARED
+items,ic2.api.items.electric.ElectricItem,applyEnchantmentEffect,method,"int applyEnchantmentEffect(ItemStack item, int amount)",DECLARED
+items,ic2.api.items.electric.ICustomElectricItem,getManager,method,IElectricItemManager getManager(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricEnchantable,getEnchantmentCompatibility,method,"InteractionResult getEnchantmentCompatibility(ItemStack stack, Enchantment ench)",DECLARED
+items,ic2.api.items.electric.IElectricEnchantable,getEnchantmentType,method,EnchantmentCategory getEnchantmentType(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricEnchantable,isBookEnchantable,method,"boolean isBookEnchantable(ItemStack stack, ItemStack book)",DECLARED
+items,ic2.api.items.electric.IElectricItem,canProvideEnergy,method,boolean canProvideEnergy(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItem,getCapacity,method,int getCapacity(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItem,getTier,method,int getTier(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItem,getTransferLimit,method,int getTransferLimit(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItemManager,charge,method,"int charge(ItemStack stack, int amount, int tier, boolean ignoreTransferLimit, boolean simulate)",DECLARED
+items,ic2.api.items.electric.IElectricItemManager,discharge,method,"int discharge(ItemStack stack, int amount, int tier, boolean ignoreTransferLimit, boolean externally, boolean simulate)",DECLARED
+items,ic2.api.items.electric.IElectricItemManager,getCharge,method,int getCharge(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItemManager,getCapacity,method,int getCapacity(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItemManager,canUse,method,"boolean canUse(ItemStack stack, int amount)",DECLARED
+items,ic2.api.items.electric.IElectricItemManager,use,method,"boolean use(ItemStack stack, int amount, LivingEntity entity)",DECLARED
+items,ic2.api.items.electric.IElectricItemManager,chargeFromArmor,method,"void chargeFromArmor(ItemStack stack, LivingEntity entity)",DECLARED
+items,ic2.api.items.electric.IElectricItemManager,getTier,method,int getTier(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItemManager,getTransferLimit,method,int getTransferLimit(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IElectricItemManager,getToolTip,method,Component getToolTip(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IFluidScanner,getScanRadius,method,"int getScanRadius(ItemStack stack, boolean useEnergy)",DECLARED
+items,ic2.api.items.electric.IFluidScanner,isValuableFluid,method,"boolean isValuableFluid(ItemStack stack, FluidState state, LevelReader world, BlockPos pos)",DECLARED
+items,ic2.api.items.electric.IFluidScanner,isValuableFluid,method,"boolean isValuableFluid(ItemStack stack, FluidState state)",DECLARED
+items,ic2.api.items.electric.IMiningDrill,canMineBlock,method,"boolean canMineBlock(ItemStack drill, BlockState state, LevelReader access, BlockPos pos)",DECLARED
+items,ic2.api.items.electric.IMiningDrill,getMiningBoost,method,"int getMiningBoost(ItemStack stack, BlockState state)",DECLARED
+items,ic2.api.items.electric.IMiningDrill,getExtraEnergyCost,method,int getExtraEnergyCost(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IMiningDrill,canDrillBeUsed,method,boolean canDrillBeUsed(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IMiningDrill,onDrillUsed,method,void onDrillUsed(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IScanner,getScanRadius,method,"int getScanRadius(ItemStack stack, boolean useEnergy)",DECLARED
+items,ic2.api.items.electric.IScanner,hasScanEffect,method,boolean hasScanEffect(ItemStack stack),DECLARED
+items,ic2.api.items.electric.IScanner,isOreValuable,method,"boolean isOreValuable(ItemStack stack, BlockState state, LevelReader world, BlockPos pos)",DECLARED
+items,ic2.api.items.electric.IScanner,isOreValuable,method,"boolean isOreValuable(ItemStack stack, BlockState state)",DECLARED
+items,ic2.api.items.electric.IScanner,getOreValue,method,"int getOreValue(ItemStack stack, BlockState state, LevelReader world, BlockPos pos)",DECLARED
+items,ic2.api.items.electric.IScanner,getOreValue,method,"int getOreValue(ItemStack stack, BlockState state)",DECLARED
+items,ic2.api.items.readers.ICropReader,isCropReader,method,boolean isCropReader(ItemStack stack),DECLARED
+items,ic2.api.items.readers.ICropReader,isCropReaderImpl,method,boolean isCropReaderImpl(ItemStack stack),DECLARED
+items,ic2.api.items.readers.IEUReader,isEUReader,method,boolean isEUReader(ItemStack stack),DECLARED
+items,ic2.api.items.readers.IEUReader,isEUReaderImpl,method,boolean isEUReaderImpl(ItemStack stack),DECLARED
+items,ic2.api.items.readers.IThermometer,isThermometer,method,boolean isThermometer(ItemStack stack),DECLARED
+items,ic2.api.items.readers.IThermometer,isThermometerImpl,method,boolean isThermometerImpl(ItemStack stack),DECLARED
+items,ic2.api.items.readers.IWrenchTool,getActualLoss,method,"double getActualLoss(ItemStack stack, double originalLoss)",DECLARED
+items,ic2.api.items.readers.IWrenchTool,shouldRenderOverlay,method,boolean shouldRenderOverlay(ItemStack stack),DECLARED
+network,ic2.api.network.INetworkManager,registerDataBuffer,method,"void registerDataBuffer(ResourceLocation location, Class<INetworkDataBuffer> clz, Supplier<INetworkDataBuffer> creator)",DECLARED
+network,ic2.api.network.INetworkManager,startGuiTracking,method,"void startGuiTracking(BlockEntity tile, Player player)",DECLARED
+network,ic2.api.network.INetworkManager,sendInitialGuiData,method,"void sendInitialGuiData(INetworkFieldProvider tile, Player player)",DECLARED
+network,ic2.api.network.INetworkManager,updateGuiData,method,"void updateGuiData(BlockEntity tile, Player player)",DECLARED
+network,ic2.api.network.INetworkManager,updateTileField,method,"void updateTileField(BlockEntity tile, String field)",DECLARED
+network,ic2.api.network.INetworkManager,updateTileFields,method,"void updateTileFields(BlockEntity tile, String... fields)",DECLARED
+network,ic2.api.network.INetworkManager,updateGuiField,method,"void updateGuiField(BlockEntity tile, String field)",DECLARED
+network,ic2.api.network.INetworkManager,updateGuiFields,method,"void updateGuiFields(BlockEntity tile, String... fields)",DECLARED
+network,ic2.api.network.INetworkManager,sendInitialData,method,"void sendInitialData(INetworkFieldProvider prov, CompoundTag nbt)",DECLARED
+network,ic2.api.network.INetworkManager,handleInitialChange,method,"void handleInitialChange(BlockEntity prov, CompoundTag nbt)",DECLARED
+network,ic2.api.network.INetworkManager,requestInitialData,method,void requestInitialData(INetworkFieldProvider prov),DECLARED
+network,ic2.api.network.INetworkManager,sendTileEvent,method,"void sendTileEvent(BlockEntity tile, int key, int value, PacketRange target)",DECLARED
+network,ic2.api.network.INetworkManager,sendTileDataBufferEvent,method,"void sendTileDataBufferEvent(BlockEntity tile, String id, INetworkDataBuffer buffer, PacketRange target)",DECLARED
+network,ic2.api.network.INetworkManager,sendClientTileEvent,method,"void sendClientTileEvent(BlockEntity tile, int key, int value)",DECLARED
+network,ic2.api.network.INetworkManager,sendClientTileDataBufferEvent,method,"void sendClientTileDataBufferEvent(BlockEntity tile, String id, INetworkDataBuffer buffer)",DECLARED
+network,ic2.api.network.INetworkManager,sendItemEvent,method,"void sendItemEvent(Player player, ItemStack stack, int key, int value)",DECLARED
+network,ic2.api.network.INetworkManager,sendItemBuffer,method,"void sendItemBuffer(Player player, ItemStack stack, String id, INetworkDataBuffer buffer)",DECLARED
+network,ic2.api.network.INetworkManager,sendClientItemEvent,method,"void sendClientItemEvent(ItemStack stack, int key, int value)",DECLARED
+network,ic2.api.network.INetworkManager,sendClientItemBuffer,method,"void sendClientItemBuffer(ItemStack stack, String id, INetworkDataBuffer buffer)",DECLARED
+network,ic2.api.network.IPlayerPacket,getContainer,method,"T getContainer(Player player, Class<T> clz)",DECLARED
+network,ic2.api.network.IPlayerPacket,getContainer,method,"void getContainer(Player player, Class<T> clz, Consumer<T> listener)",DECLARED
+network,ic2.api.network.IPlayerPacket,getOptionalContainer,method,"Optional<T> getOptionalContainer(Player player, Class<T> clz)",DECLARED
+network,ic2.api.network.IPlayerPacket,findPlayerStack,method,"ItemStack findPlayerStack(Player player, ItemStack send)",DECLARED
+network,ic2.api.network.buffer.EmptyDataBuffer,INSTANCE,field,EmptyDataBuffer INSTANCE,unknown
+network,ic2.api.network.buffer.EmptyDataBuffer,write,method,void write(IOutputBuffer buffer),DECLARED
+network,ic2.api.network.buffer.EmptyDataBuffer,read,method,void read(IInputBuffer buffer),DECLARED
+network,ic2.api.network.buffer.IBitLevelOverride,getOverride,method,"BitLevel getOverride(int fieldID, String fieldName)",DECLARED
+network,ic2.api.network.buffer.IBitLevelOverride,hasOverride,method,"boolean hasOverride(int fieldID, String fieldName)",DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readBoolean,method,boolean readBoolean(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readByte,method,byte readByte(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readShort,method,short readShort(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readMedium,method,int readMedium(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readInt,method,int readInt(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readVarInt,method,int readVarInt(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readFloat,method,float readFloat(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readDouble,method,double readDouble(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readLong,method,long readLong(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readData,method,long readData(BitLevel length),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readChar,method,char readChar(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readEnum,method,T readEnum(Class<T> clz),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readBytes,method,byte[] readBytes(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readString,method,String readString(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readNBTData,method,CompoundTag readNBTData(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readForgeRegistryEntry,method,T readForgeRegistryEntry(IForgeRegistry<T> registry),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readItemStack,method,ItemStack readItemStack(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readFluidStack,method,FluidStack readFluidStack(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readUUID,method,UUID readUUID(),DECLARED
+network,ic2.api.network.buffer.IInputBuffer,readRegistryKey,method,ResourceKey<T> readRegistryKey(ResourceKey<Registry<T>> key),DECLARED
+network,ic2.api.network.buffer.INetworkDataBuffer,write,method,void write(IOutputBuffer buffer),DECLARED
+network,ic2.api.network.buffer.INetworkDataBuffer,read,method,void read(IInputBuffer buffer),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeBoolean,method,void writeBoolean(boolean value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeByte,method,void writeByte(byte value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeShort,method,void writeShort(short value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeMedium,method,void writeMedium(int value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeInt,method,void writeInt(int value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeVarInt,method,void writeVarInt(int value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeFloat,method,void writeFloat(float value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeDouble,method,void writeDouble(double value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeLong,method,void writeLong(long value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeData,method,"void writeData(long value, BitLevel type)",DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeChar,method,void writeChar(char value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeEnum,method,void writeEnum(Enum<?> value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeString,method,void writeString(String value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeBytes,method,void writeBytes(byte[] value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeNBTData,method,void writeNBTData(CompoundTag value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeForgeEntry,method,"void writeForgeEntry(T value, IForgeRegistry<T> registry)",DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeItemStack,method,void writeItemStack(ItemStack stack),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeFluidStack,method,void writeFluidStack(FluidStack stack),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeUUID,method,void writeUUID(UUID value),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeRegistryKey,method,void writeRegistryKey(ResourceKey<?> key),DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeItemStack,method,"void writeItemStack(ItemStack stack, IOutputBuffer buffer)",DECLARED
+network,ic2.api.network.buffer.IOutputBuffer,writeEnum,method,"void writeEnum(Enum<?> value, IOutputBuffer buffer)",DECLARED
+network,ic2.api.network.container.IContainerDataEvent,onDataReceived,method,"void onDataReceived(int key, int value)",DECLARED
+network,ic2.api.network.item.INetworkItemBufferEvent,onDataBufferReceived,method,"void onDataBufferReceived(ItemStack stack, Player player, String id, T buffer, Dist targetSide)",DECLARED
+network,ic2.api.network.item.INetworkItemEvent,onEventReceived,method,"void onEventReceived(ItemStack stack, Player player, int key, int value, Dist target)",DECLARED
+network,ic2.api.network.tile.INetworkClientEventListener,onClientDataReceived,method,"void onClientDataReceived(Player entity, int key, int value)",DECLARED
+network,ic2.api.network.tile.INetworkDataEventListener,onDataBufferReceived,method,"void onDataBufferReceived(Player player, String id, INetworkDataBuffer data, Dist target)",DECLARED
+network,ic2.api.network.tile.INetworkEventListener,onServerDataReceived,method,"void onServerDataReceived(int key, int value)",DECLARED
+network,ic2.api.network.tile.INetworkFieldNotifier,onNetworkFieldChanged,method,"void onNetworkFieldChanged(Set<String> fields, Player player)",DECLARED
+network,ic2.api.network.tile.INetworkFieldNotifier,onGuiFieldChanged,method,"void onGuiFieldChanged(Set<String> fields, Player player)",DECLARED
+network,ic2.api.network.tile.INetworkFieldProvider,getNetworkFields,method,List<String> getNetworkFields(),DECLARED
+network,ic2.api.network.tile.INetworkFieldProvider,getGuiFields,method,List<String> getGuiFields(),DECLARED
+network,ic2.api.network.tile.INetworkFieldProvider,isDefaultData,method,boolean isDefaultData(String fieldName),DECLARED
+network,ic2.api.network.tile.PacketRange,PacketRange,enum,"SHORT_RANGE,LONG_RANGE,CHUNK_TRACKED,ALL_DIM,ALL_SERVER",
+reactor,ic2.api.reactor.IChamberReactor,refreshChambers,method,void refreshChambers(),DECLARED
+reactor,ic2.api.reactor.IChamberReactor,getWidth,method,int getWidth(),DECLARED
+reactor,ic2.api.reactor.IChamberReactor,getHeight,method,int getHeight(),DECLARED
+reactor,ic2.api.reactor.IReactor,getHeat,method,int getHeat(),DECLARED
+reactor,ic2.api.reactor.IReactor,setHeat,method,void setHeat(int newHeat),DECLARED
+reactor,ic2.api.reactor.IReactor,addHeat,method,void addHeat(int heat),DECLARED
+reactor,ic2.api.reactor.IReactor,getMaxHeat,method,int getMaxHeat(),DECLARED
+reactor,ic2.api.reactor.IReactor,setMaxHeat,method,void setMaxHeat(int heat),DECLARED
+reactor,ic2.api.reactor.IReactor,getHeatEffectModifier,method,float getHeatEffectModifier(),DECLARED
+reactor,ic2.api.reactor.IReactor,setHeatEffectModifier,method,void setHeatEffectModifier(float hem),DECLARED
+reactor,ic2.api.reactor.IReactor,getEnergyOutput,method,double getEnergyOutput(),DECLARED
+reactor,ic2.api.reactor.IReactor,addOutput,method,void addOutput(float output),DECLARED
+reactor,ic2.api.reactor.IReactor,getStackInReactor,method,"ItemStack getStackInReactor(int x, int y)",DECLARED
+reactor,ic2.api.reactor.IReactor,setStackInReactor,method,"void setStackInReactor(int x, int y, ItemStack stack)",DECLARED
+reactor,ic2.api.reactor.IReactor,explode,method,void explode(),DECLARED
+reactor,ic2.api.reactor.IReactor,getTickRate,method,int getTickRate(),DECLARED
+reactor,ic2.api.reactor.IReactor,isProducingEnergy,method,boolean isProducingEnergy(),DECLARED
+reactor,ic2.api.reactor.IReactorChamber,getReactor,method,IReactor getReactor(),DECLARED
+reactor,ic2.api.reactor.IReactorComponent,isValidForReactor,method,"boolean isValidForReactor(ItemStack stack, IReactor reactor)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,processChamber,method,"void processChamber(ItemStack stack, IReactor reactor, int x, int y, boolean heatCalculation, boolean damageTick)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,acceptUraniumPulse,method,"boolean acceptUraniumPulse(ItemStack stack, IReactor reactor, ItemStack source, int myX, int myY, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,canStoreHeat,method,"boolean canStoreHeat(ItemStack stack, IReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,getStoredHeat,method,"int getStoredHeat(ItemStack stack, IReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,getMaxStoredHeat,method,"int getMaxStoredHeat(ItemStack stack, IReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,storeHeat,method,"int storeHeat(ItemStack stack, IReactor reactor, int x, int y, int heatChange)",DECLARED
+reactor,ic2.api.reactor.IReactorComponent,getExplosionInfluence,method,"float getExplosionInfluence(ItemStack stack, IReactor reactor)",DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,FORMAT,field,DecimalFormat FORMAT,unknown
+reactor,ic2.api.reactor.IReactorPlannerComponent,NULL_VALUE,field,NumericTag NULL_VALUE,valueOf()
+reactor,ic2.api.reactor.IReactorPlannerComponent,applyStackSize,method,"ItemStack applyStackSize(ItemStack newStack, int size)",DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getStackSize,method,int getStackSize(ItemStack input),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,provideComponents,method,void provideComponents(NonNullList<ItemStack> list),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getComponentID,method,short getComponentID(ItemStack stack),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,createSimulationComponent,method,SimulatedStack createSimulationComponent(ItemStack self),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,addToolTip,method,"void addToolTip(ItemStack stack, Consumer<Component> tooltips)",DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,addAffectedSlots,method,"void addAffectedSlots(int x, int y, BiPredicate<Integer, Integer> slots)",DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getSupportedReactor,method,ReactorType getSupportedReactor(ItemStack stack),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getType,method,ComponentType getType(ItemStack stack),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getStats,method,List<ReactorStat> getStats(ItemStack stack),DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getReactorStat,method,"NumericTag getReactorStat(ReactorStat stat, ItemStack stack)",DECLARED
+reactor,ic2.api.reactor.IReactorPlannerComponent,getReactorStat,method,"NumericTag getReactorStat(ReactorStat stat, ItemStack stack, IReactor planner, int x, int y)",DECLARED
+reactor,ic2.api.reactor.IReactorProduct,isValidForReactor,method,"boolean isValidForReactor(ItemStack stack, IReactor reactor)",DECLARED
+reactor,ic2.api.reactor.ISteamReactor,getWaterTank,method,FluidTank getWaterTank(),DECLARED
+reactor,ic2.api.reactor.ISteamReactor,getSteamTank,method,FluidTank getSteamTank(),DECLARED
+reactor,ic2.api.reactor.IUsableUranium,createDepletedUraniumRod,method,ItemStack createDepletedUraniumRod(),DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,maxDamage,field,int maxDamage,unknown
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,damage,field,int damage,unknown
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,id,field,short id,unknown
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,save,method,CompoundTag save(),DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,load,method,void load(CompoundTag data),DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,commitState,method,void commitState(),DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,reset,method,void reset(),DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,acceptUraniumPulse,method,"boolean acceptUraniumPulse(ISimulatedReactor reactor, int x, int y, SimulatedStack source, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,canStoreHeat,method,"boolean canStoreHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,getStoredHeat,method,"int getStoredHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,getMaxStoredHeat,method,"int getMaxStoredHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,storeHeat,method,"int storeHeat(ISimulatedReactor reactor, int x, int y, int heatChange)",DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,canViewHeat,method,"boolean canViewHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,getExplosionInfluence,method,float getExplosionInfluence(ISimulatedReactor reactor),DECLARED
+reactor,ic2.api.reactor.planner.BaseDurabilitySimulatedStack,getId,method,short getId(),DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,maxHeat,field,int maxHeat,unknown
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,heat,field,int heat,unknown
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,id,field,short id,unknown
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,heatChanges,field,Tracker heatChanges,unknown
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,save,method,CompoundTag save(),DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,load,method,void load(CompoundTag data),DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,commitState,method,void commitState(),DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,reset,method,void reset(),DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,acceptUraniumPulse,method,"boolean acceptUraniumPulse(ISimulatedReactor reactor, int x, int y, SimulatedStack source, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,canStoreHeat,method,"boolean canStoreHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,getStoredHeat,method,"int getStoredHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,getMaxStoredHeat,method,"int getMaxStoredHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,storeHeat,method,"int storeHeat(ISimulatedReactor reactor, int x, int y, int heatChange)",DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,canViewHeat,method,"boolean canViewHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,getExplosionInfluence,method,float getExplosionInfluence(ISimulatedReactor reactor),DECLARED
+reactor,ic2.api.reactor.planner.BaseHeatSimulatedStack,getId,method,short getId(),DECLARED
+reactor,ic2.api.reactor.planner.FloatTracker,addChange,method,void addChange(float value),DECLARED
+reactor,ic2.api.reactor.planner.FloatTracker,commit,method,void commit(),DECLARED
+reactor,ic2.api.reactor.planner.FloatTracker,reset,method,void reset(),DECLARED
+reactor,ic2.api.reactor.planner.FloatTracker,getAverage,method,float getAverage(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,getItem,method,"SimulatedStack getItem(int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,markBroken,method,"void markBroken(int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,addBreedingPulse,method,void addBreedingPulse(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,addFuelPulse,method,void addFuelPulse(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,getHeat,method,int getHeat(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,setHeat,method,void setHeat(int newHeat),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,addHeat,method,void addHeat(int heat),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,getMaxHeat,method,int getMaxHeat(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,setMaxHeat,method,void setMaxHeat(int heat),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,getHeatEffectModifier,method,float getHeatEffectModifier(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,setHeatEffectModifier,method,void setHeatEffectModifier(float hem),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,addOutput,method,void addOutput(float output),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,getEnergyOutput,method,float getEnergyOutput(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,addSteam,method,void addSteam(int amount),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,consumeWater,method,int consumeWater(int amount),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,isProducingEnergy,method,boolean isProducingEnergy(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,isSteamReactor,method,boolean isSteamReactor(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,isSimulatingPulses,method,boolean isSimulatingPulses(),DECLARED
+reactor,ic2.api.reactor.planner.ISimulatedReactor,getGameTime,method,long getGameTime(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,NULL_VALUE,field,NumericTag NULL_VALUE,valueOf()
+reactor,ic2.api.reactor.planner.SimulatedStack,syncStack,method,ItemStack syncStack(ItemStack original),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,save,method,CompoundTag save(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,load,method,void load(CompoundTag data),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,commitState,method,void commitState(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,reset,method,void reset(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,simulate,method,"void simulate(ISimulatedReactor reactor, int x, int y, boolean heatTick, boolean damageTick)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,acceptUraniumPulse,method,"boolean acceptUraniumPulse(ISimulatedReactor reactor, int x, int y, SimulatedStack source, int sourceX, int sourceY, boolean heatRun, boolean damageTick)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,canStoreHeat,method,"boolean canStoreHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getStoredHeat,method,"int getStoredHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getMaxStoredHeat,method,"int getMaxStoredHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,storeHeat,method,"int storeHeat(ISimulatedReactor reactor, int x, int y, int heatChange)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,canViewHeat,method,"boolean canViewHeat(ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getExplosionInfluence,method,float getExplosionInfluence(ISimulatedReactor reactor),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getId,method,short getId(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getStats,method,List<ReactorStat> getStats(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getValidType,method,ReactorType getValidType(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getComponentType,method,ComponentType getComponentType(),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getStat,method,NumericTag getStat(ReactorStat stat),DECLARED
+reactor,ic2.api.reactor.planner.SimulatedStack,getStat,method,"NumericTag getStat(ReactorStat stat, ISimulatedReactor reactor, int x, int y)",DECLARED
+reactor,ic2.api.reactor.planner.Tracker,save,method,CompoundTag save(CompoundTag tag),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,load,method,void load(CompoundTag tag),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,addChange,method,void addChange(int value),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,commit,method,void commit(),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,reset,method,void reset(),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,getAverage,method,float getAverage(),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,getCount,method,int getCount(),DECLARED
+reactor,ic2.api.reactor.planner.Tracker,getTotal,method,int getTotal(),DECLARED
+recipes,ic2.api.recipes.RecipeRegistry,INGREDIENTS,field,IIngredientRegistry INGREDIENTS,unknown
+recipes,ic2.api.recipes.RecipeRegistry,CRAFTING,field,IAdvancedCraftingManager CRAFTING,unknown
+recipes,ic2.api.recipes.RecipeRegistry,UU_SHAPES,field,SidedObject<IUUMatterRegistry> UU_SHAPES,unknown
+recipes,ic2.api.recipes.RecipeRegistry,FURNACE,field,SidedObject<IMachineRecipeList> FURNACE,unknown
+recipes,ic2.api.recipes.RecipeRegistry,BLAST_FURNACE,field,SidedObject<IMachineRecipeList> BLAST_FURNACE,unknown
+recipes,ic2.api.recipes.RecipeRegistry,SMOKER,field,SidedObject<IMachineRecipeList> SMOKER,unknown
+recipes,ic2.api.recipes.RecipeRegistry,MACERATOR,field,SidedObject<IMachineRecipeList> MACERATOR,unknown
+recipes,ic2.api.recipes.RecipeRegistry,EXTRACTOR,field,SidedObject<IMachineRecipeList> EXTRACTOR,unknown
+recipes,ic2.api.recipes.RecipeRegistry,COMPRESSOR,field,SidedObject<IMachineRecipeList> COMPRESSOR,unknown
+recipes,ic2.api.recipes.RecipeRegistry,RECYCLER,field,SidedObject<IRecyclerRecipeList> RECYCLER,unknown
+recipes,ic2.api.recipes.RecipeRegistry,SAWMILL,field,SidedObject<IMachineRecipeList> SAWMILL,unknown
+recipes,ic2.api.recipes.RecipeRegistry,RARE_EARTH,field,SidedObject<IRareEarthRegistry> RARE_EARTH,unknown
+recipes,ic2.api.recipes.RecipeRegistry,CANNER,field,SidedObject<ICannerRecipeRegistry> CANNER,unknown
+recipes,ic2.api.recipes.RecipeRegistry,ELECTROLYZER,field,SidedObject<IElectrolyzerRecipeList> ELECTROLYZER,unknown
+recipes,ic2.api.recipes.RecipeRegistry,MIXING_FURNACE,field,SidedObject<IMachineRecipeList> MIXING_FURNACE,unknown
+recipes,ic2.api.recipes.RecipeRegistry,SCRAP_BOX,field,SidedObject<IScrapBoxRegistry> SCRAP_BOX,unknown
+recipes,ic2.api.recipes.RecipeRegistry,MASS_FABRICATOR,field,SidedObject<IMachineRecipeList> MASS_FABRICATOR,unknown
+recipes,ic2.api.recipes.RecipeRegistry,CAN_EFFECTS,field,IFoodCanRegistry CAN_EFFECTS,unknown
+recipes,ic2.api.recipes.RecipeRegistry,POTION_BREWING,field,SidedObject<IPotionBrewRegistry> POTION_BREWING,unknown
+recipes,ic2.api.recipes.RecipeRegistry,FLUID_FUELS,field,SidedObject<IFluidFuelRegistry> FLUID_FUELS,unknown
+recipes,ic2.api.recipes.RecipeRegistry,FUSION_REACTOR,field,SidedObject<IFusionRecipeList> FUSION_REACTOR,unknown
+recipes,ic2.api.recipes.ingridients.generators.EmptyGenerator,EMPTY,field,IOutputGenerator EMPTY,unknown
+recipes,ic2.api.recipes.ingridients.generators.EmptyGenerator,addItems,method,void addItems(Consumer<ItemStack> output),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.EmptyGenerator,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.IOutputGenerator,addItems,method,void addItems(Consumer<ItemStack> output),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.IOutputGenerator,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.ItemGenerator,addItems,method,void addItems(Consumer<ItemStack> output),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.ItemGenerator,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.ItemWithNBTGenerator,addItems,method,void addItems(Consumer<ItemStack> output),DECLARED
+recipes,ic2.api.recipes.ingridients.generators.ItemWithNBTGenerator,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ArrayInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ArrayInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ArrayInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ArrayInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ArrayInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,INSTANCE,field,IInput INSTANCE,unknown
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,asIngredient,method,Ingredient asIngredient(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.EmptyInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.FluidInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.FluidInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.FluidInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.FluidInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.FluidInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,asIngredient,method,Ingredient asIngredient(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,matchesAll,method,boolean matchesAll(ItemStack... stacks),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,matchesAny,method,boolean matchesAny(ItemStack... stacks),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,writeItemStack,method,"JsonObject writeItemStack(ItemStack stack, boolean includeSize)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,writeFluidStack,method,JsonObject writeFluidStack(FluidStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,readFluidStack,method,FluidStack readFluidStack(JsonObject obj),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,readNBT,method,CompoundTag readNBT(String s),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,copyWithSize,method,"ItemStack copyWithSize(ItemStack stack, int newSize)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,isStackEqual,method,"boolean isStackEqual(ItemStack key, ItemStack other)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IInput,isNBTExact,method,"boolean isNBTExact(ItemStack subject, ItemStack target)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.INullableInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IngredientInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IngredientInput,asIngredient,method,Ingredient asIngredient(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IngredientInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IngredientInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IngredientInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.IngredientInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemInput,asIngredient,method,Ingredient asIngredient(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,createItemList,method,IInput createItemList(ItemLike... prov),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,createItemList,method,"IInput createItemList(int size, ItemLike... prov)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,createItemList,method,"IInput createItemList(int size, boolean or, ItemLike... prov)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,createItemList,method,IInput createItemList(ItemStack... prov),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,createItemList,method,"IInput createItemList(int size, ItemStack... prov)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,createItemList,method,"IInput createItemList(int size, boolean or, ItemStack... stacks)",DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemListInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemStackInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemStackInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemStackInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemStackInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemStackInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemTagInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemTagInput,asIngredient,method,Ingredient asIngredient(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemTagInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemTagInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemTagInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.ItemTagInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.SubItemInput,asIngredient,method,Ingredient asIngredient(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.SubItemInput,getComponents,method,List<ItemStack> getComponents(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.SubItemInput,getInputSize,method,int getInputSize(),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.SubItemInput,matches,method,boolean matches(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.SubItemInput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.inputs.SubItemInput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.IInputter,addItemIntoSlot,method,"void addItemIntoSlot(int slot, ItemStack stack)",DECLARED
+recipes,ic2.api.recipes.ingridients.queue.IStackOutput,addToInventory,method,boolean addToInventory(IInputter inventory),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.IStackOutput,getStack,method,ItemStack getStack(),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.IStackOutput,save,method,void save(CompoundTag save),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.MultiStackOutput,addToInventory,method,boolean addToInventory(IInputter inventory),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.MultiStackOutput,getStack,method,ItemStack getStack(),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.MultiStackOutput,save,method,void save(CompoundTag save),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.SimpleStackOutput,addToInventory,method,boolean addToInventory(IInputter inventory),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.SimpleStackOutput,getStack,method,ItemStack getStack(),DECLARED
+recipes,ic2.api.recipes.ingridients.queue.SimpleStackOutput,save,method,void save(CompoundTag save),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.BaseRecipeOutput,generators,field,List<IOutputGenerator> generators,unknown
+recipes,ic2.api.recipes.ingridients.recipes.BaseRecipeOutput,handleGenerators,method,"void handleGenerators(List<IOutputGenerator> generators, List<ItemStack> outputs)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, IRecipeOverride overrides)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,getChance,method,float getChance(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,getAllOutputs,method,List<ItemStack> getAllOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,getMetadata,method,CompoundTag getMetadata(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,getExperience,method,float getExperience(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.ChanceRecipeOutput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IFluidRecipeOutput,onFluidRecipeProcessed,method,"List<FluidStack> onFluidRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, ItemStack input)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IFluidRecipeOutput,onFluidRecipeProcessed,method,"List<FluidStack> onFluidRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, ItemStack input, IRecipeOverride overrides)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IFluidRecipeOutput,getAllFluidOutputs,method,List<FluidStack> getAllFluidOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IFluidRecipeOutput,copyFluids,method,List<FluidStack> copyFluids(List<FluidStack> copy),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,EMPTY_COMPOUND,field,CompoundTag EMPTY_COMPOUND,unknown
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, IRecipeOverride overrides)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,getAllOutputs,method,List<ItemStack> getAllOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,getMetadata,method,CompoundTag getMetadata(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,getExperience,method,float getExperience(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutput,copyItems,method,List<ItemStack> copyItems(List<ItemStack> copy),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.IRecipeOutputChance,getChance,method,float getChance(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,getAllOutputs,method,List<ItemStack> getAllOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,onFluidRecipeProcessed,method,"List<FluidStack> onFluidRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, ItemStack input)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,getAllFluidOutputs,method,List<FluidStack> getAllFluidOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,getMetadata,method,CompoundTag getMetadata(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,getExperience,method,float getExperience(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeFluidOutput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeRecipeOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeRecipeOutput,getAllOutputs,method,List<ItemStack> getAllOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeRecipeOutput,getMetadata,method,CompoundTag getMetadata(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeRecipeOutput,getExperience,method,float getExperience(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeRecipeOutput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.RangeRecipeOutput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SawMillOutput,RECIPE_FLAG,field,String RECIPE_FLAG,"""saw_upgrade"""
+recipes,ic2.api.recipes.ingridients.recipes.SawMillOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleFluidOutput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleFluidOutput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleFluidOutput,onFluidRecipeProcessed,method,"List<FluidStack> onFluidRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags, ItemStack input)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleFluidOutput,getAllFluidOutputs,method,List<FluidStack> getAllFluidOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,outputs,field,List<ItemStack> outputs,unknown
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,nbt,field,CompoundTag nbt,unknown
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,xp,field,float xp,unknown
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,onRecipeProcessed,method,"List<ItemStack> onRecipeProcessed(RandomSource rand, CompoundTag persistentData, CompoundTag recipeFlags)",DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,getAllOutputs,method,List<ItemStack> getAllOutputs(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,getMetadata,method,CompoundTag getMetadata(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,getExperience,method,float getExperience(),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.ingridients.recipes.SimpleRecipeOutput,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.misc.ICanEffect,onFoodEaten,method,"void onFoodEaten(ItemStack stack, Player player)",DECLARED
+recipes,ic2.api.recipes.misc.ICanEffect,getTooltip,method,Component getTooltip(),DECLARED
+recipes,ic2.api.recipes.misc.ICanEffect,getOverrideIcon,method,TextureAtlasSprite getOverrideIcon(),DECLARED
+recipes,ic2.api.recipes.misc.ICanEffect,getID,method,ResourceLocation getID(),DECLARED
+recipes,ic2.api.recipes.misc.RecipeFlags,RecipeFlags,enum,"CONSUME_CONTAINERS,KEEP_IN_INPUT,HIDE_RECIPE",
+recipes,ic2.api.recipes.misc.RecipeMods,RecipeMods,enum,"ENERGY_USAGE,RECIPE_TIME",
+recipes,ic2.api.recipes.misc.SimpleCanEffect,setRandom,method,SimpleCanEffect setRandom(float chance),DECLARED
+recipes,ic2.api.recipes.misc.SimpleCanEffect,setTexture,method,SimpleCanEffect setTexture(ResourceLocation texture),DECLARED
+recipes,ic2.api.recipes.misc.SimpleCanEffect,setTooltip,method,SimpleCanEffect setTooltip(Component component),DECLARED
+recipes,ic2.api.recipes.misc.SimpleCanEffect,onFoodEaten,method,"void onFoodEaten(ItemStack stack, Player player)",DECLARED
+recipes,ic2.api.recipes.misc.SimpleCanEffect,getTooltip,method,Component getTooltip(),DECLARED
+recipes,ic2.api.recipes.misc.SimpleCanEffect,getOverrideIcon,method,TextureAtlasSprite getOverrideIcon(),DECLARED
+recipes,ic2.api.recipes.misc.SimpleCanEffect,getID,method,ResourceLocation getID(),DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addShapedIC2Recipe,method,"void addShapedIC2Recipe(String location, ItemStack output, Object... args)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addShapelessIC2Recipe,method,"void addShapelessIC2Recipe(String location, ItemStack output, Object... args)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addRepairIC2Recipe,method,"void addRepairIC2Recipe(String location, IRepairable repair, IInput repairMaterial, int effect, Object... args)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addShapedRecipe,method,"void addShapedRecipe(ResourceLocation location, ItemStack output, Object... args)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addShapelessRecipe,method,"void addShapelessRecipe(ResourceLocation location, ItemStack output, Object... args)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addRepairRecipe,method,"void addRepairRecipe(ResourceLocation id, IRepairable repair, IInput repairMaterial, int effect, Object... args)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,removeCraftingRecipe,method,void removeCraftingRecipe(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addIC2SmeltingRecipe,method,"void addIC2SmeltingRecipe(String location, ItemStack output, Object input, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addIC2SmeltingRecipe,method,"void addIC2SmeltingRecipe(String location, ItemStack output, Object input, float xp, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addIC2SmeltingRecipe,method,"void addIC2SmeltingRecipe(String location, ItemStack output, Object input, float xp, float extraTime, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addSmeltingRecipe,method,"void addSmeltingRecipe(ResourceLocation location, ItemStack output, Object input, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addSmeltingRecipe,method,"void addSmeltingRecipe(ResourceLocation location, ItemStack output, Object input, float xp, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addSmeltingRecipe,method,"void addSmeltingRecipe(ResourceLocation location, ItemStack output, Object input, float xp, float extraTime, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,removeSmeltingRecipe,method,"void removeSmeltingRecipe(ResourceLocation id, SmeltingType... types)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addStoneCutterRecipe,method,"void addStoneCutterRecipe(ResourceLocation location, ItemStack output, Object input)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addStoneCutterIC2Recipe,method,"void addStoneCutterIC2Recipe(String location, ItemStack output, Object input)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,removeStoneCutterRecipe,method,void removeStoneCutterRecipe(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addSmithingRecipe,method,"void addSmithingRecipe(ResourceLocation location, Object main, Object secondary, ItemStack output)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,addSmithingIC2Recipe,method,"void addSmithingIC2Recipe(String location, Object main, Object secondary, ItemStack output)",DECLARED
+recipes,ic2.api.recipes.registries.IAdvancedCraftingManager,removeSmithingRecipe,method,void removeSmithingRecipe(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,registerRepairable,method,"void registerRepairable(IRepairable repair, IInput input, int repairAmount)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,removeRepairable,method,void removeRepairable(IRepairable repair),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,getRepairableItem,method,"Tuple<IInput, Integer> getRepairableItem(ItemStack input, ItemStack repair, boolean compareStack)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,getRepairItems,method,"Map<Item, List<Tuple<IInput, Integer>>> getRepairItems()",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,registerFuelValue,method,"void registerFuelValue(ItemStack stack, int amount)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,registerFuelMultiplier,method,"void registerFuelMultiplier(ItemStack stack, float multiplier)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,removeValue,method,void removeValue(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,getValueForStack,method,FuelValue getValueForStack(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,getFuels,method,List<FuelValue> getFuels(),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,registerFillable,method,"void registerFillable(ItemStack container, IInput fillable, ItemStack output)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,hasContainer,method,boolean hasContainer(ItemStack container),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,removeFillable,method,void removeFillable(ItemStack container),DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,removeFillable,method,"void removeFillable(ItemStack container, ItemStack fillable)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,getFillOutput,method,"Tuple<IInput, ItemStack> getFillOutput(ItemStack container, ItemStack toFill, boolean compareStack)",DECLARED
+recipes,ic2.api.recipes.registries.ICannerRecipeRegistry,getFillables,method,"Map<ItemStack, List<Tuple<IInput, ItemStack>>> getFillables()",DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,CHARGE,field,int CHARGE,1
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,DISCHARGE,field,int DISCHARGE,2
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,addChargeRecipe,method,"void addChargeRecipe(ResourceLocation id, ItemStack input, ItemStack output, int energy)",DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,addDischargeRecipe,method,"void addDischargeRecipe(ResourceLocation id, ItemStack input, ItemStack output, int energy)",DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,addDualRecipe,method,"void addDualRecipe(ResourceLocation id, ItemStack input, ItemStack output, int energy)",DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,addRecipe,method,"void addRecipe(ResourceLocation id, ItemStack input, ItemStack output, int flags, int energy)",DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,removeRecipe,method,"void removeRecipe(ItemStack input, boolean charge)",DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,removeRecipe,method,void removeRecipe(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,getRecipes,method,List<ElectrolyzerRecipe> getRecipes(),DECLARED
+recipes,ic2.api.recipes.registries.IElectrolyzerRecipeList,getRecipe,method,"ElectrolyzerRecipe getRecipe(ItemStack input, boolean charge, boolean compareSize)",DECLARED
+recipes,ic2.api.recipes.registries.IFluidFuelRegistry,addFuel,method,"void addFuel(Fluid fluid, int ticksPerBucket, int euPerTick)",DECLARED
+recipes,ic2.api.recipes.registries.IFluidFuelRegistry,removeFuel,method,void removeFuel(Fluid fluid),DECLARED
+recipes,ic2.api.recipes.registries.IFluidFuelRegistry,getFuels,method,List<FuelEntry> getFuels(),DECLARED
+recipes,ic2.api.recipes.registries.IFluidFuelRegistry,getFuel,method,FuelEntry getFuel(Fluid fluid),DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,registerEffect,method,Item registerEffect(ICanEffect effect),DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,getEffect,method,ICanEffect getEffect(ResourceLocation location),DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,getAllEffects,method,List<ResourceLocation> getAllEffects(),DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,getEffectItem,method,Item getEffectItem(ResourceLocation item),DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,registerItemForEffect,method,"void registerItemForEffect(ItemStack stack, ResourceLocation location)",DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,getEffectForFood,method,ResourceLocation getEffectForFood(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.IFoodCanRegistry,getItemForFood,method,Item getItemForFood(ItemStack food),DECLARED
+recipes,ic2.api.recipes.registries.IFusionRecipeList,addFuel,method,"void addFuel(Item fuel, int fuelValue, float productionRate, boolean consumed)",DECLARED
+recipes,ic2.api.recipes.registries.IFusionRecipeList,getFuel,method,FusionFuel getFuel(Item item),DECLARED
+recipes,ic2.api.recipes.registries.IFusionRecipeList,removeFuel,method,void removeFuel(Item item),DECLARED
+recipes,ic2.api.recipes.registries.IFusionRecipeList,getFuels,method,List<FusionFuel> getFuels(),DECLARED
+recipes,ic2.api.recipes.registries.IFusionRecipeList,FusionFuel,method,"record FusionFuel(Item fuel, int fuelValue, float productionRate, boolean consumed)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,registerInput,method,"void registerInput(ResourceLocation location, Class<IInput> clz, Function<FriendlyByteBuf, IInput> creator, Function<JsonObject, IInput> serializer, Function<Object, IInput> maker)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,registerRecipeOutput,method,"void registerRecipeOutput(ResourceLocation location, Class<IRecipeOutput> clz, Function<FriendlyByteBuf, IRecipeOutput> creator, Function<JsonObject, IRecipeOutput> serializer)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,registerFluidOutput,method,"void registerFluidOutput(ResourceLocation location, Class<IFluidRecipeOutput> clz, Function<FriendlyByteBuf, IFluidRecipeOutput> creator, Function<JsonObject, IFluidRecipeOutput> serializer)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,registerQueue,method,"void registerQueue(ResourceLocation location, Class<IStackOutput> clz, Function<CompoundTag, IStackOutput> creator)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,registerOutputGenerators,method,"void registerOutputGenerators(ResourceLocation location, Class<IOutputGenerator> clz, Function<JsonObject, IOutputGenerator> creator)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,writeInput,method,"void writeInput(IInput input, FriendlyByteBuf buffer)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,writeRecipeOutput,method,"void writeRecipeOutput(IRecipeOutput output, FriendlyByteBuf buffer)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,writeFluidOutput,method,"void writeFluidOutput(IFluidRecipeOutput output, FriendlyByteBuf buffer)",DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,writeQueue,method,CompoundTag writeQueue(IStackOutput queue),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,readInput,method,IInput readInput(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,createOutput,method,IRecipeOutput createOutput(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,createFluidOutput,method,IFluidRecipeOutput createFluidOutput(FriendlyByteBuf buffer),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,readQueue,method,IStackOutput readQueue(CompoundTag nbt),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,readInput,method,IInput readInput(JsonObject obj),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,readOutput,method,IRecipeOutput readOutput(JsonObject obj),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,readFluidOutput,method,IFluidRecipeOutput readFluidOutput(JsonObject obj),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,readOutputGenerator,method,IOutputGenerator readOutputGenerator(JsonObject obj),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,createInputFrom,method,IInput createInputFrom(Object obj),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,serializeInput,method,JsonObject serializeInput(IInput input),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,serializeOutput,method,JsonObject serializeOutput(IRecipeOutput output),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,serializeFluidOutput,method,JsonObject serializeFluidOutput(IFluidRecipeOutput output),DECLARED
+recipes,ic2.api.recipes.registries.IIngredientRegistry,serializeOutputGenerator,method,JsonObject serializeOutputGenerator(IOutputGenerator generator),DECLARED
+recipes,ic2.api.recipes.registries.IListenableRegistry,registerListener,method,void registerListener(Consumer<T> listener),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addRecipe,method,void addRecipe(RecipeEntry recipe),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addRecipe,method,"void addRecipe(ResourceLocation id, IRecipeOutput output, IInput... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addSimpleRecipe,method,"void addSimpleRecipe(ResourceLocation id, ItemStack output, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addSimpleRecipe,method,"void addSimpleRecipe(ResourceLocation id, ItemStack output, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addXPRecipe,method,"void addXPRecipe(ResourceLocation id, ItemStack output, float xp, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addXPRecipe,method,"void addXPRecipe(ResourceLocation id, ItemStack output, float xp, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addChanceRecipe,method,"void addChanceRecipe(ResourceLocation id, ItemStack output, float xp, float chance, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addChanceRecipe,method,"void addChanceRecipe(ResourceLocation id, ItemStack output, float xp, float chance, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addRangeRecipe,method,"void addRangeRecipe(ResourceLocation id, ItemStack output, int minValue, int maxValue, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addRangeRecipe,method,"void addRangeRecipe(ResourceLocation id, ItemStack output, int minValue, int maxValue, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addRecipe,method,"void addRecipe(ResourceLocation id, IRecipeOutput output, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2SimpleRecipe,method,"void addIC2SimpleRecipe(String id, ItemStack output, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2SimpleRecipe,method,"void addIC2SimpleRecipe(String id, ItemStack output, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2XPRecipe,method,"void addIC2XPRecipe(String id, ItemStack output, float xp, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2XPRecipe,method,"void addIC2XPRecipe(String id, ItemStack output, float xp, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2ChanceRecipe,method,"void addIC2ChanceRecipe(String id, ItemStack output, float xp, float chance, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2ChanceRecipe,method,"void addIC2ChanceRecipe(String id, ItemStack output, float xp, float chance, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2RangeRecipe,method,"void addIC2RangeRecipe(String id, ItemStack output, int minValue, int maxValue, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2RangeRecipe,method,"void addIC2RangeRecipe(String id, ItemStack output, int minValue, int maxValue, CompoundTag data, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,addIC2Recipe,method,"void addIC2Recipe(String id, IRecipeOutput output, Object... inputs)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,hasRecipeForItem,method,boolean hasRecipeForItem(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,getRecipe,method,RecipeEntry getRecipe(ResourceLocation location),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,getRecipe,method,"RecipeEntry getRecipe(ItemStack stack, boolean hasStackSize)",DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,getRecipe,method,RecipeEntry getRecipe(Predicate<RecipeEntry> checker),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,removeRecipe,method,RecipeEntry removeRecipe(ResourceLocation location),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,getAllRecipes,method,List<ResourceLocation> getAllRecipes(),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,getAllEntries,method,List<RecipeEntry> getAllEntries(),DECLARED
+recipes,ic2.api.recipes.registries.IMachineRecipeList,convertInputs,method,IInput[] convertInputs(Object... inputs),DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,registerBrew,method,"void registerBrew(Item item, MobEffect potion)",DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,registerBrew,method,"void registerBrew(Item item, MobEffect fromEffect, MobEffect toEffect)",DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,removeBrew,method,void removeBrew(Item item),DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,getEffect,method,"MobEffect getEffect(Item item, MobEffect original)",DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,getEffects,method,"Map<Item, Map<MobEffect, MobEffect>> getEffects()",DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,getRequiredItems,method,List<Item> getRequiredItems(MobEffect desiredEffect),DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,registerName,method,"void registerName(MobEffect effect, String name)",DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,getName,method,String getName(MobEffect effect),DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,registerPotionContainer,method,"void registerPotionContainer(Item input, PotionContainer output)",DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,getPotionContainer,method,PotionContainer getPotionContainer(Item input),DECLARED
+recipes,ic2.api.recipes.registries.IPotionBrewRegistry,getContainers,method,"Map<Item, PotionContainer> getContainers()",DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,registerOutput,method,"void registerOutput(ResourceLocation id, ItemStack output)",DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,registerInput,method,"void registerInput(ResourceLocation id, float value, ItemStack... input)",DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,getOutputFor,method,RareEntry getOutputFor(ItemStack input),DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,getOutputFor,method,ItemStack getOutputFor(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,removeInput,method,RareEntry removeInput(ItemStack input),DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,removeOutput,method,void removeOutput(ItemStack output),DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,remove,method,void remove(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.IRareEarthRegistry,getAllRecipes,method,List<RareEntry> getAllRecipes(),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,SIMPLE,field,int SIMPLE,1
+recipes,ic2.api.recipes.registries.IRecipeFilter,FILTER,field,int FILTER,2
+recipes,ic2.api.recipes.registries.IRecipeFilter,BOTH,field,int BOTH,unknown
+recipes,ic2.api.recipes.registries.IRecipeFilter,add,method,void add(ItemLike... items),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,add,method,void add(IInput... inputs),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,remove,method,"void remove(ItemStack stack, int flags)",DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,contains,method,boolean contains(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,getFilteredItems,method,List<ItemStack> getFilteredItems(),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,clear,method,void clear(),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,serialize,method,JsonObject serialize(),DECLARED
+recipes,ic2.api.recipes.registries.IRecipeFilter,read,method,void read(JsonObject obj),DECLARED
+recipes,ic2.api.recipes.registries.IRecyclerRecipeList,getBlackList,method,IRecipeFilter getBlackList(),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,addIC2Recipe,method,Builder addIC2Recipe(String id),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,addRecipe,method,Builder addRecipe(ResourceLocation id),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,addRecipe,method,"void addRecipe(ResourceLocation location, FluidStack input, FluidStack secondInput, IInput catalyst, IFluidRecipeOutput output)",DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,getRecipe,method,FluidRecipe getRecipe(ResourceLocation location),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,getRecipe,method,"FluidRecipe getRecipe(ItemStack item, FluidStack firstTank, FluidStack secondTank, boolean testAmounts)",DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,getRecipe,method,FluidRecipe getRecipe(Predicate<FluidRecipe> checker),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,removeRecipe,method,"FluidRecipe removeRecipe(ResourceLocation location, boolean includeInverted)",DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,getAllRecipes,method,List<FluidRecipe> getAllRecipes(),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,isValidCatalyst,method,boolean isValidCatalyst(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,isValidFirstFluid,method,boolean isValidFirstFluid(FluidStack fluid),DECLARED
+recipes,ic2.api.recipes.registries.IRefiningRecipeList,isValidSecondFluid,method,boolean isValidSecondFluid(FluidStack fluid),DECLARED
+recipes,ic2.api.recipes.registries.IScrapBoxRegistry,addDrop,method,"void addDrop(ItemLike prov, float chance)",DECLARED
+recipes,ic2.api.recipes.registries.IScrapBoxRegistry,addDrop,method,"void addDrop(ItemStack stack, float chance)",DECLARED
+recipes,ic2.api.recipes.registries.IScrapBoxRegistry,getRandomDrop,method,"IDrop getRandomDrop(ItemStack source, boolean consumeItem)",DECLARED
+recipes,ic2.api.recipes.registries.IScrapBoxRegistry,removeDrops,method,void removeDrops(ItemStack stack),DECLARED
+recipes,ic2.api.recipes.registries.IScrapBoxRegistry,removeDrop,method,void removeDrop(IDrop drop),DECLARED
+recipes,ic2.api.recipes.registries.IScrapBoxRegistry,getAllDrops,method,List<IDrop> getAllDrops(),DECLARED
+recipes,ic2.api.recipes.registries.IUUMatterRegistry,registerUUShape,method,void registerUUShape(UUMatterBuilder builder),DECLARED
+recipes,ic2.api.recipes.registries.IUUMatterRegistry,registerUUEntry,method,"void registerUUEntry(ItemStack output, int milliUU)",DECLARED
+recipes,ic2.api.recipes.registries.IUUMatterRegistry,getEntries,method,List<UUMatterEntry> getEntries(),DECLARED
+recipes,ic2.api.recipes.registries.IUUMatterRegistry,removeUUEntry,method,void removeUUEntry(UUMatterEntry entry),DECLARED
+other,ic2.api.ticks.ITickScheduler,addWorldCallback,method,"void addWorldCallback(Level world, ToIntFunction<Level> ticket)",DECLARED
+other,ic2.api.ticks.ITickScheduler,addWorldCallback,method,"void addWorldCallback(Level world, ToIntFunction<Level> ticket, int delay)",DECLARED
+other,ic2.api.ticks.ITickScheduler,addServerCallback,method,void addServerCallback(ToIntFunction<MinecraftServer> ticket),DECLARED
+other,ic2.api.ticks.ITickScheduler,addServerCallback,method,"void addServerCallback(ToIntFunction<MinecraftServer> ticket, int delay)",DECLARED
+other,ic2.api.ticks.ITickScheduler,addClientCallback,method,void addClientCallback(IntSupplier ticket),DECLARED
+other,ic2.api.ticks.ITickScheduler,addClientCallback,method,"void addClientCallback(IntSupplier ticket, int delay)",DECLARED
+tiles,ic2.api.tiles.ArrayTube,getTubeType,method,TubeType getTubeType(),DECLARED
+tiles,ic2.api.tiles.ArrayTube,addItem,method,"void addItem(ItemStack item, Direction side, DyeColor color)",DECLARED
+tiles,ic2.api.tiles.ArrayTube,addItem,method,"void addItem(TransportedItem item, Direction side)",DECLARED
+tiles,ic2.api.tiles.ArrayTube,canAddItem,method,"boolean canAddItem(TransportedItem item, Direction side)",DECLARED
+tiles,ic2.api.tiles.ArrayTube,canConnect,method,"boolean canConnect(ITube other, Direction dir)",DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getValidRoom,method,int getValidRoom(ItemStack stack),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getSupportedUpgradeTypes,method,EnumSet<UpgradeType> getSupportedUpgradeTypes(),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getAvailableEnergy,method,int getAvailableEnergy(),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,useEnergy,method,"boolean useEnergy(int toUse, boolean doUse)",DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,isMachineWorking,method,boolean isMachineWorking(),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,isRedstoneSensitive,method,boolean isRedstoneSensitive(),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,setRedstoneSensitive,method,void setRedstoneSensitive(boolean flag),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,onUpgradesChanged,method,void onUpgradesChanged(),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getConnectedInventory,method,IItemHandler getConnectedInventory(Direction dir),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getConnectedTube,method,ITube getConnectedTube(Direction dir),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getWorldObj,method,Level getWorldObj(),DECLARED
+tiles,ic2.api.tiles.FakePlayerMachine,getPosition,method,BlockPos getPosition(),DECLARED
+tiles,ic2.api.tiles.IAnchorTile,hasAnchor,method,boolean hasAnchor(Direction side),DECLARED
+tiles,ic2.api.tiles.IAnchorTile,addAnchor,method,boolean addAnchor(Direction side),DECLARED
+tiles,ic2.api.tiles.IAnchorTile,removeAnchor,method,boolean removeAnchor(Direction side),DECLARED
+tiles,ic2.api.tiles.ICopyableSettings,saveSettings,method,void saveSettings(CompoundTag compound),DECLARED
+tiles,ic2.api.tiles.ICopyableSettings,loadSettings,method,void loadSettings(CompoundTag compound),DECLARED
+tiles,ic2.api.tiles.IElectrolyzerProvider,getProcessRate,method,int getProcessRate(),DECLARED
+tiles,ic2.api.tiles.IEnergyStorage,addEnergy,method,int addEnergy(int power),DECLARED
+tiles,ic2.api.tiles.IEnergyStorage,drawEnergy,method,int drawEnergy(int power),DECLARED
+tiles,ic2.api.tiles.IFluidMachine,getConnectedTank,method,IFluidHandler getConnectedTank(Direction dir),DECLARED
+tiles,ic2.api.tiles.IInputMachine,getValidRoom,method,int getValidRoom(ItemStack stack),DECLARED
+tiles,ic2.api.tiles.IMachine,getSupportedUpgradeTypes,method,EnumSet<UpgradeType> getSupportedUpgradeTypes(),DECLARED
+tiles,ic2.api.tiles.IMachine,onUpgradesChanged,method,void onUpgradesChanged(),DECLARED
+tiles,ic2.api.tiles.IMachine,getAvailableEnergy,method,int getAvailableEnergy(),DECLARED
+tiles,ic2.api.tiles.IMachine,useEnergy,method,"boolean useEnergy(int toUse, boolean doUse)",DECLARED
+tiles,ic2.api.tiles.IMachine,isMachineWorking,method,boolean isMachineWorking(),DECLARED
+tiles,ic2.api.tiles.IMachine,setRedstoneSensitive,method,void setRedstoneSensitive(boolean flag),DECLARED
+tiles,ic2.api.tiles.IMachine,isRedstoneSensitive,method,boolean isRedstoneSensitive(),DECLARED
+tiles,ic2.api.tiles.IMachine,getConnectedInventory,method,IItemHandler getConnectedInventory(Direction dir),DECLARED
+tiles,ic2.api.tiles.IMachine,getConnectedTube,method,ITube getConnectedTube(Direction dir),DECLARED
+tiles,ic2.api.tiles.INotifiableMachine,onNotify,method,void onNotify(),DECLARED
+tiles,ic2.api.tiles.IRecipeMachine,getRecipeList,method,IMachineRecipeList getRecipeList(),DECLARED
+tiles,ic2.api.tiles.ITerraformer,getBiome,method,"Holder<Biome> getBiome(Level world, BlockPos pos)",DECLARED
+tiles,ic2.api.tiles.ITerraformer,setBiome,method,"boolean setBiome(Level world, BlockPos pos, ResourceLocation biomeKey)",DECLARED
+tiles,ic2.api.tiles.ITerraformer,getFirstSolidBlockFrom,method,"BlockPos getFirstSolidBlockFrom(Level world, BlockPos pos)",DECLARED
+tiles,ic2.api.tiles.ITerraformer,getFirstBlockFrom,method,"BlockPos getFirstBlockFrom(Level world, BlockPos pos)",DECLARED
+tiles,ic2.api.tiles.ITerraformer,switchGround,method,"boolean switchGround(Level world, BlockPos pos, BlockState from, BlockState to, boolean upwards, boolean stateCompare)",DECLARED
+tiles,ic2.api.tiles.display.IDisplayInfo,REGISTRY,field,IDisplayRegistry REGISTRY,unknown
+tiles,ic2.api.tiles.display.IDisplayInfo,render,method,"void render(PoseStack stack, int x, int y, int width, int height, Alignment align, IMonitorRenderer helper)",DECLARED
+tiles,ic2.api.tiles.display.IDisplayInfo,getHeight,method,"int getHeight(int width, Alignment align)",DECLARED
+tiles,ic2.api.tiles.display.IDisplayInfo,isValid,method,boolean isValid(),DECLARED
+tiles,ic2.api.tiles.display.IDisplayInfo,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+tiles,ic2.api.tiles.display.IDisplayInfo,getServerData,method,Tag getServerData(),DECLARED
+tiles,ic2.api.tiles.display.IDisplayRegistry,register,method,"void register(ResourceLocation id, Class<IDisplayInfo> info, Function<FriendlyByteBuf, IDisplayInfo> creator)",DECLARED
+tiles,ic2.api.tiles.display.IDisplayRegistry,serialize,method,"void serialize(IDisplayInfo info, FriendlyByteBuf buffer)",DECLARED
+tiles,ic2.api.tiles.display.IDisplayRegistry,deserialize,method,IDisplayInfo deserialize(FriendlyByteBuf buffer),DECLARED
+tiles,ic2.api.tiles.display.IMonitorRenderer,getBatcher,method,MultiBufferSource getBatcher(),DECLARED
+tiles,ic2.api.tiles.display.IMonitorRenderer,getFont,method,Font getFont(),DECLARED
+tiles,ic2.api.tiles.display.IMonitorRenderer,getItemRenderer,method,ItemRenderer getItemRenderer(),DECLARED
+tiles,ic2.api.tiles.display.IMonitorRenderer,renderGuiItems,method,"void renderGuiItems(PoseStack matrix, ItemStack stack, float x, float y)",DECLARED
+tiles,ic2.api.tiles.display.IMonitorRenderer,renderGuiItemText,method,"void renderGuiItemText(PoseStack matrixstack, ItemStack stack, float x, float y, String text)",DECLARED
+tiles,ic2.api.tiles.display.IMonitorRenderer,renderGuiItemText,method,"void renderGuiItemText(PoseStack matrixstack, Font font, ItemStack stack, float x, float y, String text)",DECLARED
+tiles,ic2.api.tiles.display.impl.ItemDisplayInfo,render,method,"void render(PoseStack stack, int x, int y, int width, int height, Alignment align, IMonitorRenderer helper)",DECLARED
+tiles,ic2.api.tiles.display.impl.ItemDisplayInfo,getHeight,method,"int getHeight(int width, Alignment align)",DECLARED
+tiles,ic2.api.tiles.display.impl.ItemDisplayInfo,isValid,method,boolean isValid(),DECLARED
+tiles,ic2.api.tiles.display.impl.ItemDisplayInfo,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+tiles,ic2.api.tiles.display.impl.ItemDisplayInfo,getServerData,method,Tag getServerData(),DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,render,method,"void render(PoseStack stack, int x, int y, int width, int height, Alignment align, IMonitorRenderer helper)",DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,drawColorFrame,method,"void drawColorFrame(PoseStack stack, VertexConsumer builder, float x, float y, float width, float height, int color)",DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,darker,method,"int darker(int color, float factor)",DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,getHeight,method,"int getHeight(int width, Alignment align)",DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,isValid,method,boolean isValid(),DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+tiles,ic2.api.tiles.display.impl.ProgressDisplayInfo,getServerData,method,Tag getServerData(),DECLARED
+tiles,ic2.api.tiles.display.impl.StringDisplayInfo,render,method,"void render(PoseStack stack, int x, int y, int width, int height, Alignment align, IMonitorRenderer helper)",DECLARED
+tiles,ic2.api.tiles.display.impl.StringDisplayInfo,getHeight,method,"int getHeight(int width, Alignment align)",DECLARED
+tiles,ic2.api.tiles.display.impl.StringDisplayInfo,isValid,method,boolean isValid(),DECLARED
+tiles,ic2.api.tiles.display.impl.StringDisplayInfo,getServerData,method,Tag getServerData(),DECLARED
+tiles,ic2.api.tiles.display.impl.StringDisplayInfo,serialize,method,void serialize(FriendlyByteBuf buffer),DECLARED
+tiles,ic2.api.tiles.readers.IActivityProvider,isActivated,method,boolean isActivated(),DECLARED
+tiles,ic2.api.tiles.readers.IAirSpeed,getCurrentSpeed,method,float getCurrentSpeed(),DECLARED
+tiles,ic2.api.tiles.readers.IAirSpeed,getMaxSpeed,method,float getMaxSpeed(),DECLARED
+tiles,ic2.api.tiles.readers.IEUProducer,getEUProduction,method,float getEUProduction(),DECLARED
+tiles,ic2.api.tiles.readers.IEUStorage,getStoredEU,method,int getStoredEU(),DECLARED
+tiles,ic2.api.tiles.readers.IEUStorage,getMaxEU,method,int getMaxEU(),DECLARED
+tiles,ic2.api.tiles.readers.IEUStorage,getTier,method,int getTier(),DECLARED
+tiles,ic2.api.tiles.readers.IEUStorage,getChargeLevel,method,double getChargeLevel(),DECLARED
+tiles,ic2.api.tiles.readers.IFuelStorage,getFuel,method,int getFuel(),DECLARED
+tiles,ic2.api.tiles.readers.IFuelStorage,getMaxFuel,method,int getMaxFuel(),DECLARED
+tiles,ic2.api.tiles.readers.IProgressMachine,getProgress,method,float getProgress(),DECLARED
+tiles,ic2.api.tiles.readers.IProgressMachine,getMaxProgress,method,float getMaxProgress(),DECLARED
+tiles,ic2.api.tiles.readers.IPumpTile,getPumpProgress,method,int getPumpProgress(),DECLARED
+tiles,ic2.api.tiles.readers.IPumpTile,getPumpMaxProgress,method,int getPumpMaxProgress(),DECLARED
+tiles,ic2.api.tiles.readers.ISpeedMachine,getSpeed,method,int getSpeed(),DECLARED
+tiles,ic2.api.tiles.readers.ISpeedMachine,getMaxSpeed,method,int getMaxSpeed(),DECLARED
+tiles,ic2.api.tiles.readers.ISubProgressMachine,getSubProgress,method,float getSubProgress(),DECLARED
+tiles,ic2.api.tiles.readers.ISubProgressMachine,getMaxSubProgress,method,float getMaxSubProgress(),DECLARED
+tiles,ic2.api.tiles.readers.IWorkProvider,isWorking,method,boolean isWorking(),DECLARED
+tiles,ic2.api.tiles.readers.ReaderProvider,registerActiveProvider,method,"void registerActiveProvider(Class<?> clz, Function<BlockEntity, IActivityProvider> provider)",DECLARED
+tiles,ic2.api.tiles.readers.ReaderProvider,registerFuelProvider,method,"void registerFuelProvider(Class<?> clz, Function<BlockEntity, IFuelStorage> provider)",DECLARED
+tiles,ic2.api.tiles.readers.ReaderProvider,registerProgressProvider,method,"void registerProgressProvider(Class<?> clz, Function<BlockEntity, IProgressMachine> provider)",DECLARED
+tiles,ic2.api.tiles.readers.ReaderProvider,getFuelProvider,method,IFuelStorage getFuelProvider(BlockEntity tile),DECLARED
+tiles,ic2.api.tiles.readers.ReaderProvider,getProgressProvider,method,IProgressMachine getProgressProvider(BlockEntity tile),DECLARED
+tiles,ic2.api.tiles.readers.ReaderProvider,getActivityProvider,method,IActivityProvider getActivityProvider(BlockEntity tile),DECLARED
+tiles,ic2.api.tiles.teleporter.ITeleporterTarget,getFacing,method,Direction getFacing(),DECLARED
+tiles,ic2.api.tiles.teleporter.ITeleporterTarget,getSendType,method,TeleportType getSendType(),DECLARED
+tiles,ic2.api.tiles.teleporter.ITeleporterTarget,canReceive,method,boolean canReceive(TeleportType type),DECLARED
+tiles,ic2.api.tiles.teleporter.ITeleporterTarget,setTarget,method,boolean setTarget(TeleporterTarget target),DECLARED
+tiles,ic2.api.tiles.teleporter.ITeleporterTarget,hasTarget,method,boolean hasTarget(TeleporterTarget target),DECLARED
+tiles,ic2.api.tiles.teleporter.TargetRegistry,INSTANCE,field,TargetRegistry INSTANCE,unknown
+tiles,ic2.api.tiles.teleporter.TargetRegistry,addTarget,method,"void addTarget(TeleporterTarget target, String name)",DECLARED
+tiles,ic2.api.tiles.teleporter.TargetRegistry,removeTarget,method,void removeTarget(TeleporterTarget target),DECLARED
+tiles,ic2.api.tiles.teleporter.TargetRegistry,getTargetName,method,String getTargetName(TeleporterTarget target),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,write,method,void write(IOutputBuffer buffer),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,read,method,void read(IInputBuffer buffer),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,getDimension,method,ResourceKey<Level> getDimension(),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,getTargetPosition,method,BlockPos getTargetPosition(),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,getWorld,method,ServerLevel getWorld(),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,getTile,method,BlockEntity getTile(),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,isSame,method,boolean isSame(BlockEntity tile),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,isSame,method,"boolean isSame(ResourceKey<Level> type, BlockPos pos)",DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,hashCode,method,int hashCode(),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,equals,method,boolean equals(Object obj),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,readFromBuffer,method,TeleporterTarget readFromBuffer(IInputBuffer buffer),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,read,method,TeleporterTarget read(CompoundTag nbt),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,write,method,CompoundTag write(),DECLARED
+tiles,ic2.api.tiles.teleporter.TeleporterTarget,write,method,CompoundTag write(CompoundTag nbt),DECLARED
+tiles,ic2.api.tiles.tubes.IItemCache,CACHE,field,SidedObject<IItemCache> CACHE,unknown
+tiles,ic2.api.tiles.tubes.IItemCache,getCache,method,IItemCache getCache(),DECLARED
+tiles,ic2.api.tiles.tubes.IItemCache,getItem,method,Supplier<ItemStack> getItem(int id),DECLARED
+tiles,ic2.api.tiles.tubes.IItemCache,registerItem,method,int registerItem(ItemStack stack),DECLARED
+tiles,ic2.api.tiles.tubes.IItemCache,updateCache,method,void updateCache(),DECLARED
+tiles,ic2.api.tiles.tubes.IItemCache,clearCache,method,void clearCache(),DECLARED
+tiles,ic2.api.tiles.tubes.ILimiterTube,getValidColors,method,EnumSet<DyeColor> getValidColors(),DECLARED
+tiles,ic2.api.tiles.tubes.IProviderTube,provideItems,method,"int provideItems(ItemStack stack, int amount, DyeColor color, UUID requestId)",DECLARED
+tiles,ic2.api.tiles.tubes.IProviderTube,getItemsProvided,method,void getItemsProvided(ObjIntConsumer<ItemStack> listener),DECLARED
+tiles,ic2.api.tiles.tubes.IProviderTube,getProviderSource,method,long getProviderSource(),DECLARED
+tiles,ic2.api.tiles.tubes.IRequestTube,provideRequests,method,void provideRequests(ITubeRequester requested),DECLARED
+tiles,ic2.api.tiles.tubes.IRequestTube,onRequestsReset,method,void onRequestsReset(),DECLARED
+tiles,ic2.api.tiles.tubes.IRequestTube,onRequestFulfilled,method,"void onRequestFulfilled(ItemStack stack, int amount)",DECLARED
+tiles,ic2.api.tiles.tubes.IRequestTube,getRequestId,method,UUID getRequestId(),DECLARED
+tiles,ic2.api.tiles.tubes.IRequestTube,onRequestLost,method,"void onRequestLost(ItemStack stack, int amount)",DECLARED
+tiles,ic2.api.tiles.tubes.IRequestTube,getRequestSource,method,long getRequestSource(),DECLARED
+tiles,ic2.api.tiles.tubes.ITube,addItem,method,"void addItem(ItemStack item, Direction side)",DECLARED
+tiles,ic2.api.tiles.tubes.ITube,addItem,method,"void addItem(ItemStack item, Direction side, DyeColor color)",DECLARED
+tiles,ic2.api.tiles.tubes.ITube,addItem,method,"void addItem(TransportedItem item, Direction side)",DECLARED
+tiles,ic2.api.tiles.tubes.ITube,canAddItem,method,"boolean canAddItem(TransportedItem item, Direction side)",DECLARED
+tiles,ic2.api.tiles.tubes.ITube,canConnect,method,"boolean canConnect(ITube other, Direction dir)",DECLARED
+tiles,ic2.api.tiles.tubes.ITube,getTubeType,method,TubeType getTubeType(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,MIN_SPEED,field,int MIN_SPEED,1
+tiles,ic2.api.tiles.tubes.TransportedItem,MAX_SPEED,field,int MAX_SPEED,100
+tiles,ic2.api.tiles.tubes.TransportedItem,timeOut,field,byte timeOut,0
+tiles,ic2.api.tiles.tubes.TransportedItem,invalid,field,boolean invalid,false
+tiles,ic2.api.tiles.tubes.TransportedItem,readFromNetwork,method,TransportedItem readFromNetwork(IInputBuffer buffer),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,read,method,TransportedItem read(CompoundTag nbt),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,readFromNBT,method,void readFromNBT(CompoundTag nbt),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,writeToNBT,method,CompoundTag writeToNBT(CompoundTag nbt),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,read,method,void read(IInputBuffer buffer),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,write,method,void write(IOutputBuffer buffer),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,serializeEssentials,method,short serializeEssentials(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,deserializeEssentials,method,void deserializeEssentials(short data),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getId,method,int getId(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getRequestId,method,UUID getRequestId(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,isCentering,method,boolean isCentering(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getServerStack,method,ItemStack getServerStack(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getStack,method,ItemStack getStack(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getProgress,method,byte getProgress(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,isInvalid,method,boolean isInvalid(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getColor,method,DyeColor getColor(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setColor,method,TransportedItem setColor(DyeColor color),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setAttemptedDirections,method,void setAttemptedDirections(DirectionList list),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setRequestId,method,TransportedItem setRequestId(UUID id),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,invalidate,method,void invalidate(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,hasReachedCenter,method,boolean hasReachedCenter(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,hasReachedEnd,method,boolean hasReachedEnd(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getTransferDirection,method,Direction getTransferDirection(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getTravelingDirection,method,Direction getTravelingDirection(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,getAttemptedDirections,method,DirectionList getAttemptedDirections(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,clearDirections,method,void clearDirections(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setCentering,method,void setCentering(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setInsertionDirection,method,void setInsertionDirection(Direction dir),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setExportDirection,method,void setExportDirection(Direction dir),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,update,method,void update(),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,setStartSpeed,method,TransportedItem setStartSpeed(int speed),DECLARED
+tiles,ic2.api.tiles.tubes.TransportedItem,updateSpeed,method,"boolean updateSpeed(int newSpeed, int change)",DECLARED
+other,ic2.api.util.DirectionList,DOWN,field,DirectionList DOWN,ofFacing()
+other,ic2.api.util.DirectionList,UP,field,DirectionList UP,ofFacing()
+other,ic2.api.util.DirectionList,NORTH,field,DirectionList NORTH,ofFacing()
+other,ic2.api.util.DirectionList,SOUTH,field,DirectionList SOUTH,ofFacing()
+other,ic2.api.util.DirectionList,EAST,field,DirectionList EAST,ofFacing()
+other,ic2.api.util.DirectionList,WEST,field,DirectionList WEST,ofFacing()
+other,ic2.api.util.DirectionList,VERTICAL,field,DirectionList VERTICAL,add()
+other,ic2.api.util.DirectionList,HORIZONTAL,field,DirectionList HORIZONTAL,ofFacings()
+other,ic2.api.util.DirectionList,POSITIVE,field,DirectionList POSITIVE,ofFacings()
+other,ic2.api.util.DirectionList,NEGATIVE,field,DirectionList NEGATIVE,ofFacings()
+other,ic2.api.util.DirectionList,X_AXIS,field,DirectionList X_AXIS,add()
+other,ic2.api.util.DirectionList,Z_AXIS,field,DirectionList Z_AXIS,add()
+other,ic2.api.util.DirectionList,XY_AXIS,field,DirectionList XY_AXIS,add()
+other,ic2.api.util.DirectionList,YZ_AXIS,field,DirectionList YZ_AXIS,add()
+other,ic2.api.util.DirectionList,P_CORNER,field,DirectionList P_CORNER,add()
+other,ic2.api.util.DirectionList,N_CORNER,field,DirectionList N_CORNER,add()
+other,ic2.api.util.DirectionList,ALL,field,DirectionList ALL,ofNumber()
+other,ic2.api.util.DirectionList,EMPTY,field,DirectionList EMPTY,ofNumber()
+other,ic2.api.util.DirectionList,ofFacing,method,DirectionList ofFacing(Direction facing),DECLARED
+other,ic2.api.util.DirectionList,ofFacings,method,DirectionList ofFacings(Direction... facings),DECLARED
+other,ic2.api.util.DirectionList,ofFacings,method,DirectionList ofFacings(Collection<Direction> facings),DECLARED
+other,ic2.api.util.DirectionList,ofAxis,method,DirectionList ofAxis(Axis axis),DECLARED
+other,ic2.api.util.DirectionList,ofFlags,method,DirectionList ofFlags(boolean... flags),DECLARED
+other,ic2.api.util.DirectionList,ofNumber,method,DirectionList ofNumber(int index),DECLARED
+other,ic2.api.util.DirectionList,getName,method,MutableComponent getName(Direction dir),DECLARED
+other,ic2.api.util.DirectionList,rotate,method,DirectionList rotate(int amount),DECLARED
+other,ic2.api.util.DirectionList,invert,method,DirectionList invert(),DECLARED
+other,ic2.api.util.DirectionList,opposite,method,DirectionList opposite(),DECLARED
+other,ic2.api.util.DirectionList,add,method,DirectionList add(Direction facing),DECLARED
+other,ic2.api.util.DirectionList,add,method,DirectionList add(DirectionList facings),DECLARED
+other,ic2.api.util.DirectionList,remove,method,DirectionList remove(Direction facing),DECLARED
+other,ic2.api.util.DirectionList,remove,method,DirectionList remove(DirectionList facings),DECLARED
+other,ic2.api.util.DirectionList,set,method,"DirectionList set(Direction facing, boolean value)",DECLARED
+other,ic2.api.util.DirectionList,keep,method,DirectionList keep(DirectionList facings),DECLARED
+other,ic2.api.util.DirectionList,flip,method,DirectionList flip(Direction dir),DECLARED
+other,ic2.api.util.DirectionList,contains,method,boolean contains(Direction direction),DECLARED
+other,ic2.api.util.DirectionList,contains,method,boolean contains(DirectionList facings),DECLARED
+other,ic2.api.util.DirectionList,containsAny,method,boolean containsAny(DirectionList facings),DECLARED
+other,ic2.api.util.DirectionList,notContains,method,boolean notContains(Direction direction),DECLARED
+other,ic2.api.util.DirectionList,containsNot,method,boolean containsNot(DirectionList facings),DECLARED
+other,ic2.api.util.DirectionList,invertFacing,method,DirectionList invertFacing(Direction facing),DECLARED
+other,ic2.api.util.DirectionList,replace,method,"DirectionList replace(Direction oldFacing, Direction newFacing)",DECLARED
+other,ic2.api.util.DirectionList,getNextFacing,method,Direction getNextFacing(Direction facing),DECLARED
+other,ic2.api.util.DirectionList,getPrevFacing,method,Direction getPrevFacing(Direction facing),DECLARED
+other,ic2.api.util.DirectionList,getOffset,method,BlockPos getOffset(),DECLARED
+other,ic2.api.util.DirectionList,getCode,method,int getCode(),DECLARED
+other,ic2.api.util.DirectionList,size,method,int size(),DECLARED
+other,ic2.api.util.DirectionList,isEmpty,method,boolean isEmpty(),DECLARED
+other,ic2.api.util.DirectionList,isFull,method,boolean isFull(),DECLARED
+other,ic2.api.util.DirectionList,toString,method,String toString(),DECLARED
+other,ic2.api.util.DirectionList,toFacings,method,Set<Direction> toFacings(),DECLARED
+other,ic2.api.util.DirectionList,getRandomFacing,method,Direction getRandomFacing(),DECLARED
+other,ic2.api.util.DirectionList,getRandomFacing,method,Direction getRandomFacing(Direction defaultValue),DECLARED
+other,ic2.api.util.DirectionList,getDefaultFacing,method,Direction getDefaultFacing(),DECLARED
+other,ic2.api.util.DirectionList,toFlags,method,boolean[] toFlags(),DECLARED
+other,ic2.api.util.DirectionList,getNeighborState,method,"BlockState getNeighborState(BlockEntity tile, Direction dir)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborState,method,"BlockState getNeighborState(Level world, BlockPos pos, Direction dir)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborTile,method,"BlockEntity getNeighborTile(BlockEntity tile, Direction dir)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborTile,method,"BlockEntity getNeighborTile(Level world, BlockPos pos, Direction dir)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborCapability,method,"LazyOptional<T> getNeighborCapability(BlockEntity tile, Direction dir, Capability<T> capability)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborCapability,method,"LazyOptional<T> getNeighborCapability(Level world, BlockPos pos, Direction dir, Capability<T> capability)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborInterface,method,"T getNeighborInterface(BlockEntity tile, Direction dir, Class<T> clazz)",DECLARED
+other,ic2.api.util.DirectionList,getNeighborInterface,method,"T getNeighborInterface(Level world, BlockPos pos, Direction dir, Class<T> clazz)",DECLARED
+other,ic2.api.util.DirectionList,getRotation,method,"Rotation getRotation(Direction source, Direction other)",DECLARED
+other,ic2.api.util.DirectionList,rotateAround,method,"Direction rotateAround(Direction dir, Direction axis)",DECLARED
+other,ic2.api.util.DirectionList,rotateY,method,Direction rotateY(Direction dir),DECLARED
+other,ic2.api.util.DirectionList,toNumber,method,int toNumber(Direction... facings),DECLARED
+other,ic2.api.util.DirectionList,toNumber,method,int toNumber(Collection<Direction> facings),DECLARED
+other,ic2.api.util.DirectionList,toNumber,method,int toNumber(boolean... facings),DECLARED
+other,ic2.api.util.DirectionList,toFlags,method,boolean[] toFlags(Direction... facings),DECLARED
+other,ic2.api.util.DirectionList,test,method,boolean test(Direction t),DECLARED
+other,ic2.api.util.DirectionList,iterator,method,Iterator<Direction> iterator(),DECLARED
+other,ic2.api.util.DirectionList,getRandomIterator,method,Iterable<Direction> getRandomIterator(),DECLARED
+other,ic2.api.util.IC2DamageSource,ELECTRICITY,field,IC2DamageSource ELECTRICITY,unknown
+other,ic2.api.util.IC2DamageSource,NUKE,field,IC2DamageSource NUKE,unknown
+other,ic2.api.util.IC2DamageSource,RADIATION,field,IC2DamageSource RADIATION,unknown
+other,ic2.api.util.IC2DamageSource,newShockDamage,method,IC2DamageSource newShockDamage(Entity entity),DECLARED
+other,ic2.api.util.IC2DamageSource,getEntity,method,Entity getEntity(),DECLARED
+other,ic2.api.util.ILocation,getWorldObj,method,Level getWorldObj(),DECLARED
+other,ic2.api.util.ILocation,getPosition,method,BlockPos getPosition(),DECLARED
+other,ic2.api.util.SidedObject,set,method,"void set(T value, boolean serverSide)",DECLARED
+other,ic2.api.util.SidedObject,get,method,T get(),DECLARED
+other,ic2.api.util.SidedObject,get,method,T get(boolean serverSide),DECLARED
+other,ic2.api.util.SidedObject,isSimulating,method,boolean isSimulating(),DECLARED

--- a/tools/generate_api_inventory.py
+++ b/tools/generate_api_inventory.py
@@ -1,0 +1,376 @@
+import json
+import csv
+import re
+from pathlib import Path
+import javalang
+
+SRC_ROOT = Path('src/main/java')
+OUTPUT_DIR = Path('inventory_v2')
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+packages = set()
+interfaces = []
+abstract_classes = []
+concrete_classes = []
+enums = []
+events = []
+capability_hints = []
+reactor_blueprint_hints = []
+
+method_catalog_rows = []
+
+DOMAIN_MAP = {
+    'ic2.api.energy': 'energy',
+    'ic2.api.reactor': 'reactor',
+    'ic2.api.tiles': 'tiles',
+    'ic2.api.items': 'items',
+    'ic2.api.network': 'network',
+    'ic2.api.recipes': 'recipes',
+    'ic2.api.events': 'events',
+}
+
+def detect_domain(pkg):
+    for prefix, domain in DOMAIN_MAP.items():
+        if pkg == prefix or pkg.startswith(prefix + '.'):
+            return domain
+    return 'other'
+
+
+def preprocess_source(source):
+    # Handle Java pattern matching for instanceof used in conjunction with &&
+    pattern_and = re.compile(r'(?P<expr>[A-Za-z0-9_\.()]+)\s+instanceof\s+(?P<type>[A-Za-z0-9_$.]+)\s+(?P<var>[A-Za-z0-9_]+)\s*&&\s*(?P=var)(?P<tail>[^;]+)')
+
+    def repl_and(match):
+        expr = match.group('expr')
+        type_name = match.group('type')
+        tail = match.group('tail')
+        return f"{expr} instanceof {type_name} && (({type_name}) {expr}){tail}"
+
+    source = pattern_and.sub(repl_and, source)
+
+    # Handle ternary pattern matching: expr instanceof Type var ? var : other
+    pattern_ternary = re.compile(r'(?P<expr>[A-Za-z0-9_\.()]+)\s+instanceof\s+(?P<type>[A-Za-z0-9_$.]+)\s+(?P<var>[A-Za-z0-9_]+)\s*\?\s*(?P=var)\s*:\s*')
+
+    def repl_ternary(match):
+        expr = match.group('expr')
+        type_name = match.group('type')
+        return f"{expr} instanceof {type_name} ? ({type_name}) {expr} : "
+
+    source = pattern_ternary.sub(repl_ternary, source)
+
+    # Replace method references like Type[]::new used in toArray calls with array constructors.
+    pattern_array_ctor = re.compile(r'toArray\(\s*([A-Za-z0-9_$.]+)\[\]\s*::\s*new\s*\)')
+
+    def repl_array_ctor(match):
+        type_name = match.group(1)
+        return f"toArray(new {type_name}[0])"
+
+    source = pattern_array_ctor.sub(repl_array_ctor, source)
+
+    return source
+
+
+def strip_comments(source):
+    source = re.sub(r'/\*.*?\*/', '', source, flags=re.S)
+    source = re.sub(r'//.*', '', source)
+    return source
+
+
+def fallback_interface_parse(source, pkg, rel_path):
+    text = strip_comments(source)
+    match = re.search(r'public\s+interface\s+(?P<name>[A-Za-z0-9_]+)', text)
+    if not match:
+        return
+    name = match.group('name')
+    fqcn = f"{pkg}.{name}" if pkg else name
+    body_start = text.find('{', match.end())
+    if body_start == -1:
+        return
+    body = text[body_start + 1:]
+    sentinel = body.find('class ')
+    if sentinel != -1:
+        body = body[:sentinel]
+    methods = []
+    constants = []
+    buffer = []
+    depth = 0
+    for ch in body:
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            if depth == 0:
+                break
+            depth -= 1
+        buffer.append(ch)
+    statements = ''.join(buffer).split(';')
+    for stmt in statements:
+        stmt = stmt.strip()
+        if not stmt:
+            continue
+        if '(' in stmt and ')' in stmt and not stmt.startswith('class '):
+            if stmt.strip().startswith(('for', 'if', 'while', 'switch')):
+                continue
+            signature = stmt.replace('\n', ' ')
+            signature = re.sub(r'\s+', ' ', signature)
+            signature = signature + ';'
+            method_name = signature.split('(')[0].split()[-1]
+            methods.append({
+                'name': method_name,
+                'sig': signature,
+                'notes': 'DECLARED (fallback)',
+            })
+            method_catalog_rows.append((detect_domain(pkg), fqcn, method_name, 'method', signature, 'DECLARED (fallback)'))
+        elif '=' in stmt:
+            parts = stmt.split('=')
+            left = parts[0].strip().split()
+            if left:
+                name_part = left[-1]
+                type_part = ' '.join(left[:-1])
+                method_catalog_rows.append((detect_domain(pkg), fqcn, name_part, 'field', f"{type_part} {name_part}", 'unknown'))
+                constants.append({
+                    'name': name_part,
+                    'value': 'unknown',
+                    'notes': 'DECLARED (fallback)',
+                })
+
+    interfaces.append({
+        'fqcn': fqcn,
+        'methods': methods,
+        'constants': constants,
+        'related': [],
+        'domain': detect_domain(pkg),
+        'source': str(rel_path),
+    })
+
+
+def type_kind(node):
+    if isinstance(node, javalang.tree.ClassDeclaration):
+        if 'abstract' in (node.modifiers or []):
+            return 'abstract'
+        return 'class'
+    if isinstance(node, javalang.tree.InterfaceDeclaration):
+        return 'interface'
+    if isinstance(node, javalang.tree.EnumDeclaration):
+        return 'enum'
+    return 'other'
+
+
+def type_to_str(t):
+    if t is None:
+        return 'void'
+    if isinstance(t, str):
+        return t
+    if isinstance(t, javalang.tree.BasicType):
+        result = t.name
+        if t.dimensions:
+            result += '[]' * len(t.dimensions)
+        return result
+    if isinstance(t, javalang.tree.ReferenceType):
+        result = '.'.join(t.name.parts) if hasattr(t.name, 'parts') else t.name
+        if t.arguments:
+            args = []
+            for arg in t.arguments:
+                if isinstance(arg, javalang.tree.TypeArgument):
+                    arg_type = getattr(arg, 'type', None)
+                    kind = getattr(arg, 'kind', None)
+                    if kind == 'extends' and arg_type is not None:
+                        args.append(f"? extends {type_to_str(arg_type)}")
+                    elif kind == 'super' and arg_type is not None:
+                        args.append(f"? super {type_to_str(arg_type)}")
+                    elif arg_type is not None:
+                        args.append(type_to_str(arg_type))
+                    else:
+                        args.append('?')
+                else:
+                    args.append(type_to_str(arg))
+            result += '<' + ', '.join(args) + '>'
+        if t.dimensions:
+            result += '[]' * len(t.dimensions)
+        return result
+    if hasattr(t, 'name'):
+        return t.name
+    return str(t)
+
+
+def format_parameter(param):
+    param_type = type_to_str(param.type)
+    if param.varargs:
+        param_type += '...'
+    return f"{param_type} {param.name}"
+
+
+def get_constant_value(decl):
+    init = decl.initializer
+    if init is None:
+        return 'unknown'
+    if isinstance(init, javalang.tree.Literal):
+        return init.value
+    if isinstance(init, javalang.tree.MemberReference):
+        return init.member
+    if isinstance(init, javalang.tree.MethodInvocation):
+        return init.member + '()'
+    if isinstance(init, javalang.tree.Cast):
+        return f"({type_to_str(init.type)})"
+    return 'unknown'
+
+
+def type_refs_to_names(type_refs):
+    if not type_refs:
+        return []
+    names = []
+    for ref in type_refs:
+        if isinstance(ref, javalang.tree.Type):
+            names.append(type_to_str(ref))
+        elif hasattr(ref, 'name'):
+            names.append(type_to_str(ref))
+        else:
+            names.append(str(ref))
+    return names
+
+
+def record_method(domain, fqcn, method):
+    params = ', '.join(format_parameter(p) for p in method.parameters)
+    ret = type_to_str(method.return_type)
+    signature = f"{ret} {method.name}({params})"
+    method_catalog_rows.append((domain, fqcn, method.name, 'method', signature, 'DECLARED'))
+    return signature
+
+
+def record_field(domain, fqcn, field, declarator):
+    type_name = type_to_str(field.type)
+    name = declarator.name
+    value = get_constant_value(declarator)
+    method_catalog_rows.append((domain, fqcn, name, 'field', f"{type_name} {name}", value))
+    return value
+
+
+for path in sorted(SRC_ROOT.rglob('*.java')):
+    rel_path = path.relative_to(SRC_ROOT)
+    with path.open('r', encoding='utf-8') as fh:
+        source = preprocess_source(fh.read())
+    try:
+        tree = javalang.parse.parse(source)
+    except (javalang.parser.JavaSyntaxError, IndexError) as exc:
+        print(f"Failed to parse {rel_path}: {exc}")
+        fallback_interface_parse(source, pkg, rel_path)
+        continue
+
+    pkg = tree.package.name if tree.package else ''
+    if pkg:
+        packages.add(pkg)
+    domain = detect_domain(pkg)
+
+    for type_decl in tree.types:
+        fqcn = f"{pkg}.{type_decl.name}" if pkg else type_decl.name
+        kind = type_kind(type_decl)
+
+        if kind == 'enum':
+            values = [const.name for const in getattr(type_decl.body, 'constants', [])]
+            enums.append({
+                'fqcn': fqcn,
+                'values': values,
+                'domain': domain,
+            })
+            method_catalog_rows.append((domain, fqcn, type_decl.name, 'enum', ','.join(values), ''))
+        elif kind == 'interface':
+            methods = []
+            constants = []
+            for field in type_decl.fields:
+                for declarator in field.declarators:
+                    value = record_field(domain, fqcn, field, declarator)
+                    constants.append({
+                        'name': declarator.name,
+                        'value': value,
+                        'notes': 'DECLARED',
+                    })
+            for method in type_decl.methods:
+                signature = record_method(domain, fqcn, method)
+                methods.append({
+                    'name': method.name,
+                    'sig': signature,
+                    'notes': 'DECLARED',
+                })
+            interfaces.append({
+                'fqcn': fqcn,
+                'methods': methods,
+                'constants': constants,
+                'related': type_refs_to_names(type_decl.extends),
+                'domain': domain,
+            })
+        elif kind in {'abstract', 'class'}:
+            methods = []
+            constants = []
+            for field in type_decl.fields:
+                if any(mod in {'public', 'protected'} for mod in (field.modifiers or [])):
+                    for declarator in field.declarators:
+                        value = record_field(domain, fqcn, field, declarator)
+                        constants.append({
+                            'name': declarator.name,
+                            'value': value,
+                            'notes': 'DECLARED',
+                        })
+            for method in type_decl.methods:
+                if any(mod in {'public', 'protected', 'abstract'} for mod in (method.modifiers or [])):
+                    signature = record_method(domain, fqcn, method)
+                    methods.append({
+                        'name': method.name,
+                        'sig': signature,
+                        'notes': 'DECLARED',
+                    })
+            class_entry = {
+                'fqcn': fqcn,
+                'methods': methods,
+                'constants': constants,
+                'related': sorted(set(type_refs_to_names(type_decl.extends) + type_refs_to_names(type_decl.implements))),
+                'domain': domain,
+            }
+            if kind == 'abstract':
+                abstract_classes.append(class_entry)
+            else:
+                concrete_classes.append(class_entry)
+
+        if pkg.startswith('ic2.api.events') and isinstance(type_decl, javalang.tree.ClassDeclaration):
+            fields = []
+            for field in type_decl.fields:
+                if 'public' in (field.modifiers or []):
+                    for decl in field.declarators:
+                        fields.append({'name': decl.name, 'type': type_to_str(field.type)})
+            events.append({
+                'fqcn': fqcn,
+                'fields': fields,
+                'when': 'INFERRED',
+            })
+
+        if 'Planner' in type_decl.name or 'Simulated' in type_decl.name or 'Tracker' in type_decl.name:
+            reactor_blueprint_hints.append({
+                'class': fqcn,
+                'hint': 'INFERRED planner/simulated/tracker role from name',
+            })
+
+    if 'ForgeCapabilities' in source:
+        capability_hints.append({
+            'name': 'ForgeCapabilities',
+            'source': str(rel_path),
+            'notes': 'DECLARED reference in source',
+        })
+
+packages = sorted(packages)
+
+api_contracts = {
+    'packages': packages,
+    'interfaces': interfaces,
+    'abstract_classes': abstract_classes,
+    'enums': enums,
+    'events': events,
+    'capability_hints': capability_hints,
+    'reactor_blueprint_hints': reactor_blueprint_hints,
+}
+
+with (OUTPUT_DIR / 'api_contracts.json').open('w', encoding='utf-8') as fh:
+    json.dump(api_contracts, fh, indent=2)
+
+with (OUTPUT_DIR / 'method_catalog.csv').open('w', encoding='utf-8', newline='') as fh:
+    writer = csv.writer(fh)
+    writer.writerow(['domain', 'fqcn', 'member', 'kind', 'signature_or_value', 'notes'])
+    for row in method_catalog_rows:
+        writer.writerow(row)


### PR DESCRIPTION
## Summary
- add a Python-based scanner that parses the IC2 API sources into machine-readable inventories
- generate API_BEHAVIORS.md, api_contracts.json, method_catalog.csv, and behavior_edges.mmd under inventory_v2
- document energy, reactor, tiles, items, network, recipes, and events contracts with implementation checklists

## Testing
- python tools/generate_api_inventory.py

------
https://chatgpt.com/codex/tasks/task_e_68e28a9d65e483319e3e5b04ae65b4a6